### PR TITLE
feat: transactional email templates API + Go SDK + CLI

### DIFF
--- a/apps/web/app/(main)/api/internal/v1/email-templates/handler.ts
+++ b/apps/web/app/(main)/api/internal/v1/email-templates/handler.ts
@@ -664,19 +664,30 @@ export async function publishEmailTemplate(
     );
   }
 
-  // Validate template has content JSON for rendering
-  if (!template.emailContent?.contentJson) {
+  // Validate template has renderable content: either visual JSON (dashboard
+  // editor) or raw HTML uploaded via the external transactional-email-templates
+  // API.
+  const hasContentJson = Boolean(template.emailContent?.contentJson);
+  const hasContentHtml = Boolean(template.emailContent?.contentHtml);
+  if (!hasContentJson && !hasContentHtml) {
     throw new BadRequestError(
       "Cannot publish a template without content. Add content before publishing.",
       ErrorCode.TEMPLATE_NO_CONTENT,
     );
   }
 
-  // Render HTML from contentJson (with empty variables to preserve placeholders)
-  const contentJson = template.emailContent
-    .contentJson as unknown as BroadcastDocument;
-  const styles = (template.emailContent.styles as BroadcastStyles) || {};
-  const contentHtml = await renderBroadcastToHtml(contentJson, {}, styles);
+  let contentHtml: string;
+  if (hasContentJson) {
+    // Render HTML from contentJson (with empty variables to preserve placeholders)
+    const contentJson = template.emailContent
+      .contentJson as unknown as BroadcastDocument;
+    const styles = (template.emailContent.styles as BroadcastStyles) || {};
+    contentHtml = await renderBroadcastToHtml(contentJson, {}, styles);
+  } else {
+    // HTML-only path: trust the already-stored HTML (external API sets this
+    // directly on create/update and has already run HTML + compliance checks).
+    contentHtml = template.emailContent!.contentHtml!;
+  }
 
   // Generate plain text from HTML
   const contentText = htmlToPlainText(contentHtml);

--- a/apps/web/app/(main)/api/v1/emails/send/handler.ts
+++ b/apps/web/app/(main)/api/v1/emails/send/handler.ts
@@ -197,7 +197,7 @@ async function resolveTemplateContent(
 
   // 3. Validate compliance variables on template HTML
   if (publishedVersion.emailContent.contentHtml) {
-    const compliance = validateEmailCompliance(publishedVersion.emailContent.contentHtml);
+    const compliance = validateEmailCompliance(publishedVersion.emailContent.contentHtml, { type: "TRANSACTIONAL" });
     if (!compliance.valid) {
       throw new BadRequestError(
         `Email template is missing required compliance variables: ${compliance.missing.join(", ")}`,
@@ -288,7 +288,7 @@ export async function sendTransactionalEmail(
     previewText = data.previewText;
 
     // Validate compliance variables on raw HTML
-    const compliance = validateEmailCompliance(html);
+    const compliance = validateEmailCompliance(html, { type: "TRANSACTIONAL" });
     if (!compliance.valid) {
       throw new BadRequestError(
         `Email HTML is missing required compliance variables: ${compliance.missing.join(", ")}`,

--- a/apps/web/app/(main)/api/v1/marketing-emails/handler.ts
+++ b/apps/web/app/(main)/api/v1/marketing-emails/handler.ts
@@ -91,7 +91,7 @@ export async function createMarketingEmail(
         ErrorCode.VALIDATION_FAILED,
       );
     }
-    const compliance = validateEmailCompliance(data.html);
+    const compliance = validateEmailCompliance(data.html, { type: "MARKETING" });
     if (!compliance.valid) {
       throw new BadRequestError(
         `Email is missing required compliance variables: ${compliance.missing.join(", ")}`,
@@ -242,7 +242,7 @@ export async function updateMarketingEmail(
   }
 
   if (typeof data.html === "string") {
-    const compliance = validateEmailCompliance(data.html);
+    const compliance = validateEmailCompliance(data.html, { type: "MARKETING" });
     if (!compliance.valid) {
       throw new BadRequestError(
         `Email is missing required compliance variables: ${compliance.missing.join(", ")}`,

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/preview/route.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/preview/route.ts
@@ -1,0 +1,30 @@
+/**
+ * Preview Transactional Email Template Route (External API)
+ *
+ * GET /api/v1/transactional-email-templates/[templateId]/preview
+ *
+ * Returns the HTML body with SAMPLE_VARIABLES substituted so callers
+ * can render the template for QA without a live send.
+ *
+ * Authentication: API Key (Bearer token)
+ */
+
+import type { NextRequest } from "next/server";
+import { withApiSession, withErrorHandling } from "@/lib/api/requests";
+import { previewTransactionalEmailTemplate } from "../../handler";
+
+interface RouteParams {
+  params: Promise<{ templateId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        previewTransactionalEmailTemplate(apiKey.workspaceId, templateId),
+      ["read:templates"],
+    ),
+  );
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/publish/route.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/publish/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Publish Transactional Email Template Route (External API)
+ *
+ * POST /api/v1/transactional-email-templates/[templateId]/publish
+ *
+ * Authentication: API Key (Bearer token)
+ */
+
+import type { NextRequest } from "next/server";
+import { withApiSession, withErrorHandling } from "@/lib/api/requests";
+import { publishTransactionalEmailTemplate } from "../../handler";
+
+interface RouteParams {
+  params: Promise<{ templateId: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        publishTransactionalEmailTemplate(apiKey.workspaceId, templateId),
+      ["manage:templates"],
+    ),
+  );
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/route.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/route.ts
@@ -1,0 +1,61 @@
+/**
+ * Individual Transactional Email Template Route (External API)
+ *
+ * GET    /api/v1/transactional-email-templates/[templateId]  - Get template
+ * PUT    /api/v1/transactional-email-templates/[templateId]  - Update (DRAFT only)
+ * DELETE /api/v1/transactional-email-templates/[templateId]  - Delete (DRAFT only)
+ *
+ * Authentication: API Key (Bearer token)
+ */
+
+import type { NextRequest } from "next/server";
+import { withApiSession, withErrorHandling } from "@/lib/api/requests";
+import {
+  deleteTransactionalEmailTemplate,
+  getTransactionalEmailTemplate,
+  updateTransactionalEmailTemplate,
+} from "../handler";
+
+interface RouteParams {
+  params: Promise<{ templateId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        getTransactionalEmailTemplate(apiKey.workspaceId, templateId),
+      ["read:templates"],
+    ),
+  );
+}
+
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey, request) =>
+        updateTransactionalEmailTemplate(
+          apiKey.workspaceId,
+          templateId,
+          request,
+        ),
+      ["manage:templates"],
+    ),
+  );
+}
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        deleteTransactionalEmailTemplate(apiKey.workspaceId, templateId),
+      ["manage:templates"],
+    ),
+  );
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/versions/route.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/[templateId]/versions/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Transactional Email Template Versions Route (External API)
+ *
+ * GET  /api/v1/transactional-email-templates/[templateId]/versions  - List versions
+ * POST /api/v1/transactional-email-templates/[templateId]/versions  - Create a new DRAFT version
+ *
+ * Authentication: API Key (Bearer token)
+ */
+
+import type { NextRequest } from "next/server";
+import { withApiSession, withErrorHandling } from "@/lib/api/requests";
+import {
+  createTransactionalEmailTemplateVersion,
+  listTransactionalEmailTemplateVersions,
+} from "../../handler";
+
+interface RouteParams {
+  params: Promise<{ templateId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        listTransactionalEmailTemplateVersions(apiKey.workspaceId, templateId),
+      ["read:templates"],
+    ),
+  );
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const { templateId } = await params;
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey) =>
+        createTransactionalEmailTemplateVersion(apiKey.workspaceId, templateId),
+      ["manage:templates"],
+    ),
+  );
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/handler.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/handler.ts
@@ -1,0 +1,516 @@
+/**
+ * Transactional Email Templates Handler (External API)
+ *
+ * Business logic for the HTML-only transactional template REST surface.
+ *
+ * Unlike the internal dashboard handler (which stores visual-editor JSON
+ * and renders HTML at publish time), this external handler persists raw
+ * HTML directly on `EmailContent.contentHtml` and relies on the unified
+ * publish path in `../../internal/v1/email-templates/handler` to
+ * materialize text + mark the row PUBLISHED.
+ *
+ * Auth: API key.
+ * Scopes: `read:templates` / `manage:templates`.
+ */
+
+import type { NextRequest } from "next/server";
+import { ErrorCode } from "@/lib/api/error-codes";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from "@/lib/api/errors";
+import {
+  createCursorPaginatedResponse,
+  parseCursorPaginationParams,
+} from "@/lib/api/pagination";
+import { responseCreated, responseOk } from "@/lib/api/responses";
+import { validateRequestBody } from "@/lib/api/validation";
+import { prisma } from "@/lib/db";
+import { htmlToPlainText } from "@/lib/email/html-to-text";
+import { validateEmailCompliance } from "@/lib/emails/compliance-validation";
+import { validateEmailHtml } from "@/lib/emails/html-validation";
+import { SAMPLE_VARIABLES, extractVariables } from "@/lib/emails/variables";
+import {
+  publishEmailTemplate as publishEmailTemplateInternal,
+  createEmailTemplateVersion as createEmailTemplateVersionInternal,
+  listEmailTemplateVersions as listEmailTemplateVersionsInternal,
+} from "../../internal/v1/email-templates/handler";
+import {
+  createTransactionalEmailTemplateSchema,
+  updateTransactionalEmailTemplateSchema,
+} from "./schema";
+
+/**
+ * Validates that optional sender identity IDs belong to the workspace.
+ */
+async function validateSenderIdentities(
+  workspaceId: string,
+  senderIdentityId?: string | null,
+  replyToIdentityId?: string | null,
+): Promise<void> {
+  const identityIds = [senderIdentityId, replyToIdentityId].filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  );
+  if (identityIds.length === 0) return;
+
+  const identities = await prisma.senderIdentity.findMany({
+    where: { id: { in: identityIds }, workspaceId },
+    select: { id: true },
+  });
+  const foundIds = new Set(identities.map((i) => i.id));
+
+  if (senderIdentityId && !foundIds.has(senderIdentityId)) {
+    throw new NotFoundError(
+      "Sender identity not found",
+      ErrorCode.RESOURCE_NOT_FOUND,
+    );
+  }
+  if (replyToIdentityId && !foundIds.has(replyToIdentityId)) {
+    throw new NotFoundError(
+      "Reply-to identity not found",
+      ErrorCode.RESOURCE_NOT_FOUND,
+    );
+  }
+}
+
+/**
+ * Runs the two mandatory HTML gates for transactional templates.
+ */
+function validateTransactionalHtml(html: string): void {
+  const structural = validateEmailHtml(html);
+  if (!structural.valid) {
+    throw new BadRequestError(
+      structural.errors.map((e) => e.message).join("; "),
+      ErrorCode.VALIDATION_FAILED,
+    );
+  }
+  const compliance = validateEmailCompliance(html, { type: "TRANSACTIONAL" });
+  if (!compliance.valid) {
+    throw new BadRequestError(
+      `Transactional template is missing required compliance variables: ${compliance.missing.join(", ")}`,
+      ErrorCode.VALIDATION_FAILED,
+    );
+  }
+}
+
+interface TemplateWithContent {
+  id: string;
+  name: string;
+  description: string | null;
+  uniqueSlug: string | null;
+  status: string;
+  version: number;
+  parentId: string | null;
+  senderIdentityId: string | null;
+  replyToIdentityId: string | null;
+  trackClicks: boolean;
+  trackOpens: boolean;
+  publishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  emailContent: {
+    subject: string | null;
+    previewText: string | null;
+    contentHtml: string | null;
+    contentText: string | null;
+    variables: unknown;
+  } | null;
+}
+
+function formatTransactionalTemplate(template: TemplateWithContent) {
+  const html = template.emailContent?.contentHtml ?? null;
+  return {
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    uniqueSlug: template.uniqueSlug,
+    status: template.status,
+    version: template.version,
+    parentId: template.parentId,
+    subject: template.emailContent?.subject ?? null,
+    previewText: template.emailContent?.previewText ?? null,
+    html,
+    text: template.emailContent?.contentText ?? null,
+    variables: html ? extractVariables(html) : [],
+    variableDefinitions: template.emailContent?.variables ?? [],
+    senderIdentityId: template.senderIdentityId,
+    replyToIdentityId: template.replyToIdentityId,
+    trackClicks: template.trackClicks,
+    trackOpens: template.trackOpens,
+    publishedAt: template.publishedAt?.toISOString() ?? null,
+    createdAt: template.createdAt.toISOString(),
+    updatedAt: template.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * POST /api/v1/transactional-email-templates
+ *
+ * Create a transactional email template. By default the template is
+ * created and published atomically; pass `publish: false` to keep it
+ * as a DRAFT.
+ */
+export async function createTransactionalEmailTemplate(
+  workspaceId: string,
+  request: NextRequest,
+) {
+  const data = await validateRequestBody(
+    createTransactionalEmailTemplateSchema,
+    request,
+  );
+
+  validateTransactionalHtml(data.html);
+  await validateSenderIdentities(
+    workspaceId,
+    data.senderIdentityId,
+    data.replyToIdentityId,
+  );
+
+  const contentHtml = data.html;
+  const contentText = htmlToPlainText(data.html);
+  const now = new Date();
+
+  try {
+    const template = await prisma.$transaction(async (tx) => {
+      const emailContent = await tx.emailContent.create({
+        data: {
+          subject: data.subject,
+          previewText: data.previewText,
+          contentHtml,
+          contentText,
+          variables: data.variables ?? undefined,
+        },
+      });
+
+      return tx.emailTemplate.create({
+        data: {
+          workspaceId,
+          name: data.name,
+          description: data.description,
+          uniqueSlug: data.uniqueSlug,
+          emailContentId: emailContent.id,
+          senderIdentityId: data.senderIdentityId,
+          replyToIdentityId: data.replyToIdentityId,
+          trackClicks: data.trackClicks,
+          trackOpens: data.trackOpens,
+          status: data.publish ? "PUBLISHED" : "DRAFT",
+          version: 1,
+          publishedAt: data.publish ? now : null,
+          // self-reference published version on first publish
+          ...(data.publish ? {} : {}),
+        },
+      });
+    });
+
+    // For a published template the `publishedVersionId` must point at
+    // itself. Prisma cannot self-reference in the same create, so we do
+    // it in a follow-up update.
+    if (data.publish) {
+      await prisma.emailTemplate.update({
+        where: { id: template.id },
+        data: { publishedVersionId: template.id },
+      });
+    }
+
+    return responseCreated(
+      {
+        id: template.id,
+        uniqueSlug: template.uniqueSlug,
+        status: data.publish ? "PUBLISHED" : "DRAFT",
+      },
+      "transactional_email_template",
+    );
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code: string }).code === "P2002"
+    ) {
+      throw new ConflictError(
+        "A template with this unique slug already exists in the workspace",
+        ErrorCode.RESOURCE_ALREADY_EXISTS,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * GET /api/v1/transactional-email-templates
+ *
+ * List root transactional templates (parentId = null) with cursor
+ * pagination. Versions are fetched via the `/versions` sub-endpoint.
+ */
+export async function listTransactionalEmailTemplates(
+  workspaceId: string,
+  request: NextRequest,
+) {
+  const { limit, after, before } = parseCursorPaginationParams(request);
+
+  const baseQuery = {
+    where: {
+      workspaceId,
+      parentId: null,
+    },
+    include: { emailContent: true },
+    orderBy: before ? { id: "asc" as const } : { id: "desc" as const },
+    take: limit + 1,
+  };
+
+  const templates = after
+    ? await prisma.emailTemplate.findMany({
+        ...baseQuery,
+        cursor: { id: after },
+        skip: 1,
+      })
+    : before
+      ? await prisma.emailTemplate.findMany({
+          ...baseQuery,
+          cursor: { id: before },
+          skip: 1,
+        })
+      : await prisma.emailTemplate.findMany(baseQuery);
+
+  const hasMore = templates.length > limit;
+  const items = hasMore ? templates.slice(0, -1) : templates;
+  if (before) items.reverse();
+
+  return responseOk(
+    createCursorPaginatedResponse(
+      items.map(formatTransactionalTemplate),
+      hasMore,
+      "transactional_email_template_list",
+    ),
+  );
+}
+
+async function findTemplateOrThrow(workspaceId: string, templateId: string) {
+  const template = await prisma.emailTemplate.findFirst({
+    where: { id: templateId, workspaceId },
+    include: { emailContent: true },
+  });
+  if (!template) {
+    throw new NotFoundError(
+      "Transactional email template not found",
+      ErrorCode.RESOURCE_NOT_FOUND,
+    );
+  }
+  return template;
+}
+
+/**
+ * GET /api/v1/transactional-email-templates/[templateId]
+ */
+export async function getTransactionalEmailTemplate(
+  workspaceId: string,
+  templateId: string,
+) {
+  const template = await findTemplateOrThrow(workspaceId, templateId);
+  return responseOk(
+    formatTransactionalTemplate(template),
+    "transactional_email_template",
+  );
+}
+
+/**
+ * PUT /api/v1/transactional-email-templates/[templateId]
+ *
+ * Update a DRAFT transactional template. Published templates are
+ * immutable — create a new version via POST /versions first.
+ */
+export async function updateTransactionalEmailTemplate(
+  workspaceId: string,
+  templateId: string,
+  request: NextRequest,
+) {
+  const data = await validateRequestBody(
+    updateTransactionalEmailTemplateSchema,
+    request,
+  );
+
+  const existing = await findTemplateOrThrow(workspaceId, templateId);
+
+  if (existing.status !== "DRAFT") {
+    throw new BadRequestError(
+      "Only templates in DRAFT status can be edited. Create a new version to modify a published template.",
+      ErrorCode.INVALID_PARAMETER,
+    );
+  }
+
+  if (data.uniqueSlug !== undefined && existing.parentId !== null) {
+    throw new BadRequestError(
+      "Unique slug can only be set on the parent template, not on versions.",
+      ErrorCode.INVALID_PARAMETER,
+    );
+  }
+
+  if (typeof data.html === "string") {
+    validateTransactionalHtml(data.html);
+  }
+
+  await validateSenderIdentities(
+    workspaceId,
+    data.senderIdentityId === undefined ? undefined : data.senderIdentityId,
+    data.replyToIdentityId === undefined ? undefined : data.replyToIdentityId,
+  );
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (existing.emailContentId) {
+        const contentUpdate: Record<string, unknown> = {};
+        if (data.subject !== undefined) contentUpdate.subject = data.subject;
+        if (data.previewText !== undefined)
+          contentUpdate.previewText = data.previewText;
+        if (typeof data.html === "string") {
+          contentUpdate.contentHtml = data.html;
+          contentUpdate.contentText = htmlToPlainText(data.html);
+        }
+        if (data.variables !== undefined)
+          contentUpdate.variables = data.variables;
+
+        if (Object.keys(contentUpdate).length > 0) {
+          await tx.emailContent.update({
+            where: { id: existing.emailContentId },
+            data: contentUpdate,
+          });
+        }
+      }
+
+      await tx.emailTemplate.update({
+        where: { id: templateId },
+        data: {
+          ...(data.name !== undefined && { name: data.name }),
+          ...(data.description !== undefined && {
+            description: data.description,
+          }),
+          ...(data.uniqueSlug !== undefined && {
+            uniqueSlug: data.uniqueSlug,
+          }),
+          ...(data.senderIdentityId !== undefined && {
+            senderIdentityId: data.senderIdentityId,
+          }),
+          ...(data.replyToIdentityId !== undefined && {
+            replyToIdentityId: data.replyToIdentityId,
+          }),
+          ...(data.trackClicks !== undefined && {
+            trackClicks: data.trackClicks,
+          }),
+          ...(data.trackOpens !== undefined && {
+            trackOpens: data.trackOpens,
+          }),
+        },
+      });
+    });
+
+    return responseOk({ id: templateId }, "transactional_email_template");
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code: string }).code === "P2002"
+    ) {
+      throw new ConflictError(
+        "A template with this unique slug already exists in the workspace",
+        ErrorCode.RESOURCE_ALREADY_EXISTS,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * DELETE /api/v1/transactional-email-templates/[templateId]
+ */
+export async function deleteTransactionalEmailTemplate(
+  workspaceId: string,
+  templateId: string,
+) {
+  const template = await findTemplateOrThrow(workspaceId, templateId);
+
+  if (template.status !== "DRAFT") {
+    throw new BadRequestError(
+      "Only templates in DRAFT status can be deleted.",
+      ErrorCode.INVALID_PARAMETER,
+    );
+  }
+
+  await prisma.emailTemplate.delete({ where: { id: templateId } });
+  if (template.emailContentId) {
+    await prisma.emailContent.delete({
+      where: { id: template.emailContentId },
+    });
+  }
+  return responseOk({ id: templateId }, "transactional_email_template");
+}
+
+/**
+ * POST /api/v1/transactional-email-templates/[templateId]/publish
+ *
+ * Delegates to the shared publish pipeline. Re-runs transactional
+ * compliance on the persisted HTML to catch anyone who mutated the
+ * row out of band.
+ */
+export async function publishTransactionalEmailTemplate(
+  workspaceId: string,
+  templateId: string,
+) {
+  const template = await findTemplateOrThrow(workspaceId, templateId);
+  if (template.emailContent?.contentHtml) {
+    validateTransactionalHtml(template.emailContent.contentHtml);
+  }
+  return publishEmailTemplateInternal(workspaceId, templateId);
+}
+
+/**
+ * GET /api/v1/transactional-email-templates/[templateId]/preview
+ *
+ * Returns the HTML with SAMPLE_VARIABLES substituted so consumers can
+ * preview the template without a full send.
+ */
+export async function previewTransactionalEmailTemplate(
+  workspaceId: string,
+  templateId: string,
+) {
+  const template = await findTemplateOrThrow(workspaceId, templateId);
+  const html = template.emailContent?.contentHtml ?? null;
+
+  if (!html) {
+    return responseOk(
+      { html: null, hasContent: false },
+      "transactional_email_template_preview",
+    );
+  }
+
+  const preview = html.replace(
+    /\{\{(\w+(?:\.\w+)*)\}\}/g,
+    (match, varName) => SAMPLE_VARIABLES[varName] ?? match,
+  );
+
+  return responseOk(
+    { html: preview, hasContent: true },
+    "transactional_email_template_preview",
+  );
+}
+
+/**
+ * POST /api/v1/transactional-email-templates/[templateId]/versions
+ */
+export async function createTransactionalEmailTemplateVersion(
+  workspaceId: string,
+  templateId: string,
+) {
+  return createEmailTemplateVersionInternal(workspaceId, templateId);
+}
+
+/**
+ * GET /api/v1/transactional-email-templates/[templateId]/versions
+ */
+export async function listTransactionalEmailTemplateVersions(
+  workspaceId: string,
+  templateId: string,
+) {
+  return listEmailTemplateVersionsInternal(workspaceId, templateId);
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/route.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Transactional Email Templates Collection Route (External API)
+ *
+ * GET    /api/v1/transactional-email-templates   - List templates
+ * POST   /api/v1/transactional-email-templates   - Create a template
+ *
+ * Authentication: API Key (Bearer token)
+ */
+
+import type { NextRequest } from "next/server";
+import { withApiSession, withErrorHandling } from "@/lib/api/requests";
+import {
+  createTransactionalEmailTemplate,
+  listTransactionalEmailTemplates,
+} from "./handler";
+
+export async function GET(request: NextRequest) {
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey, request) =>
+        listTransactionalEmailTemplates(apiKey.workspaceId, request),
+      ["read:templates"],
+    ),
+  );
+}
+
+export async function POST(request: NextRequest) {
+  return withErrorHandling(request, () =>
+    withApiSession(
+      request,
+      (apiKey, request) =>
+        createTransactionalEmailTemplate(apiKey.workspaceId, request),
+      ["manage:templates"],
+    ),
+  );
+}

--- a/apps/web/app/(main)/api/v1/transactional-email-templates/schema.ts
+++ b/apps/web/app/(main)/api/v1/transactional-email-templates/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * Transactional Email Templates Validation Schemas (External API)
+ *
+ * Zod schemas for the HTML-only transactional template REST surface.
+ * Different from the internal visual-editor schemas: `html` is the source
+ * of truth here, there is no `contentJson` / `styles`, and `subject` is
+ * required on create (transactional mail must have a subject).
+ */
+
+import { z } from "zod";
+
+// Letters, numbers, underscores, hyphens. Must start with a letter.
+const uniqueSlugPattern = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+export const variableDefinitionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(["text", "number"]),
+});
+
+export type VariableDefinition = z.infer<typeof variableDefinitionSchema>;
+
+/**
+ * Create a new transactional email template.
+ *
+ * - `html` is required — this is the source of truth for rendering.
+ * - `uniqueSlug` is required and is the identifier used by
+ *   `POST /v1/emails/send` when referencing `template.id`.
+ * - `publish: true` (the default) creates and publishes the template
+ *   atomically. Pass `publish: false` to keep it as a DRAFT for later
+ *   editing.
+ */
+export const createTransactionalEmailTemplateSchema = z.object({
+  name: z.string().min(1, "Name is required").max(255),
+  description: z.string().max(1000).optional(),
+  uniqueSlug: z
+    .string()
+    .min(1, "Unique slug is required")
+    .max(100)
+    .regex(
+      uniqueSlugPattern,
+      "Unique slug must start with a letter and contain only letters, numbers, underscores, or hyphens",
+    ),
+  subject: z.string().min(1, "Subject is required").max(1000),
+  previewText: z.string().max(1000).optional(),
+  html: z
+    .string()
+    .min(1, "HTML body is required")
+    .max(10_000_000, "HTML body exceeds 10 MB limit"),
+  senderIdentityId: z.string().min(1).optional(),
+  replyToIdentityId: z.string().min(1).optional(),
+  trackClicks: z.boolean().optional().default(true),
+  trackOpens: z.boolean().optional().default(true),
+  variables: z.array(variableDefinitionSchema).optional(),
+  publish: z.boolean().optional().default(true),
+});
+
+export type CreateTransactionalEmailTemplateInput = z.infer<
+  typeof createTransactionalEmailTemplateSchema
+>;
+
+/**
+ * Update an existing transactional email template (DRAFT only).
+ *
+ * All fields are optional. Publishing is a separate endpoint
+ * (POST /publish).
+ */
+export const updateTransactionalEmailTemplateSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(1000).optional().nullable(),
+  uniqueSlug: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(
+      uniqueSlugPattern,
+      "Unique slug must start with a letter and contain only letters, numbers, underscores, or hyphens",
+    )
+    .optional(),
+  subject: z.string().min(1).max(1000).optional(),
+  previewText: z.string().max(1000).optional().nullable(),
+  html: z.string().min(1).max(10_000_000).optional(),
+  senderIdentityId: z.string().min(1).optional().nullable(),
+  replyToIdentityId: z.string().min(1).optional().nullable(),
+  trackClicks: z.boolean().optional(),
+  trackOpens: z.boolean().optional(),
+  variables: z.array(variableDefinitionSchema).optional(),
+});
+
+export type UpdateTransactionalEmailTemplateInput = z.infer<
+  typeof updateTransactionalEmailTemplateSchema
+>;

--- a/apps/web/lib/api/responses.ts
+++ b/apps/web/lib/api/responses.ts
@@ -81,7 +81,10 @@ export type ApiObjectType =
   | "broadcast_stats"
   | "marketing_email"
   | "marketing_email_list"
-  | "marketing_email_stats";
+  | "marketing_email_stats"
+  | "transactional_email_template"
+  | "transactional_email_template_list"
+  | "transactional_email_template_preview";
 
 /**
  * Standard API response structure (for external API v1)

--- a/apps/web/lib/emails/compliance-validation.ts
+++ b/apps/web/lib/emails/compliance-validation.ts
@@ -1,31 +1,61 @@
 import { extractVariables } from "./variables";
 
-const REQUIRED_COMPLIANCE_VARIABLES = [
-  { name: "business_address", label: "Business address ({{business_address}})" },
+export type EmailComplianceType = "TRANSACTIONAL" | "MARKETING";
+
+interface RequiredVariable {
+  name: string;
+  label: string;
+}
+
+const BUSINESS_ADDRESS: RequiredVariable = {
+  name: "business_address",
+  label: "Business address ({{business_address}})",
+};
+
+const MARKETING_REQUIRED_VARIABLES: RequiredVariable[] = [
+  BUSINESS_ADDRESS,
   { name: "unsubscribe_url", label: "Unsubscribe link ({{unsubscribe_url}})" },
   { name: "terms_url", label: "Terms of service link ({{terms_url}})" },
   { name: "privacy_url", label: "Privacy policy link ({{privacy_url}})" },
 ];
+
+// Transactional mail (password resets, receipts, magic links, OTP, etc.) must
+// still carry a physical business address under CAN-SPAM / similar regimes,
+// but MUST NOT carry unsubscribe links, and terms/privacy links are optional.
+const TRANSACTIONAL_REQUIRED_VARIABLES: RequiredVariable[] = [BUSINESS_ADDRESS];
 
 export interface ComplianceCheckResult {
   valid: boolean;
   missing: string[];
 }
 
-export function validateEmailCompliance(html: string): ComplianceCheckResult {
+export interface ValidateEmailComplianceOptions {
+  type?: EmailComplianceType;
+}
+
+export function validateEmailCompliance(
+  html: string,
+  options: ValidateEmailComplianceOptions = {},
+): ComplianceCheckResult {
+  const type = options.type ?? "MARKETING";
+  const required =
+    type === "TRANSACTIONAL"
+      ? TRANSACTIONAL_REQUIRED_VARIABLES
+      : MARKETING_REQUIRED_VARIABLES;
+
   if (!html) {
     return {
       valid: false,
-      missing: REQUIRED_COMPLIANCE_VARIABLES.map((v) => v.label),
+      missing: required.map((v) => v.label),
     };
   }
 
   const presentVariables = new Set(extractVariables(html));
   const missing: string[] = [];
 
-  for (const required of REQUIRED_COMPLIANCE_VARIABLES) {
-    if (!presentVariables.has(required.name)) {
-      missing.push(required.label);
+  for (const variable of required) {
+    if (!presentVariables.has(variable.name)) {
+      missing.push(variable.label);
     }
   }
 

--- a/apps/web/tests/api/v1/transactional-email-templates/crud.spec.ts
+++ b/apps/web/tests/api/v1/transactional-email-templates/crud.spec.ts
@@ -1,0 +1,376 @@
+/**
+ * Integration tests for Transactional Email Templates (External API)
+ *
+ * Covers:
+ * - POST   /api/v1/transactional-email-templates
+ * - GET    /api/v1/transactional-email-templates
+ * - GET    /api/v1/transactional-email-templates/[templateId]
+ * - PUT    /api/v1/transactional-email-templates/[templateId]
+ * - DELETE /api/v1/transactional-email-templates/[templateId]
+ * - POST   /api/v1/transactional-email-templates/[templateId]/publish
+ * - GET    /api/v1/transactional-email-templates/[templateId]/preview
+ * - GET    /api/v1/transactional-email-templates/[templateId]/versions
+ * - POST   /api/v1/transactional-email-templates/[templateId]/versions
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  GET as LIST,
+  POST,
+} from "@/app/(main)/api/v1/transactional-email-templates/route";
+import {
+  DELETE,
+  GET,
+  PUT,
+} from "@/app/(main)/api/v1/transactional-email-templates/[templateId]/route";
+import { POST as PUBLISH } from "@/app/(main)/api/v1/transactional-email-templates/[templateId]/publish/route";
+import { GET as PREVIEW } from "@/app/(main)/api/v1/transactional-email-templates/[templateId]/preview/route";
+import {
+  GET as LIST_VERSIONS,
+  POST as CREATE_VERSION,
+} from "@/app/(main)/api/v1/transactional-email-templates/[templateId]/versions/route";
+import {
+  type CreatedApiKey,
+  cleanupWorkspace,
+  createFullAccessApiKey,
+  createTestApiKey,
+  createTestWorkspace,
+  del,
+  get,
+  post,
+  put,
+  type TestWorkspace,
+} from "@/tests/utils";
+
+let testWorkspace: TestWorkspace;
+let fullAccessApiKey: CreatedApiKey;
+
+// Transactional templates only require {{business_address}} — no unsubscribe.
+const TRANSACTIONAL_HTML = `<html><body><h1>Receipt</h1><p>Hello {{firstName}}</p><footer>{{business_address}}</footer></body></html>`;
+const UPDATED_HTML = `<html><body><h1>Updated Receipt</h1><footer>{{business_address}}</footer></body></html>`;
+
+function basePath(suffix = "") {
+  return `/transactional-email-templates${suffix}`;
+}
+
+beforeAll(async () => {
+  testWorkspace = createTestWorkspace();
+  fullAccessApiKey = await createFullAccessApiKey(testWorkspace.id);
+});
+
+afterAll(async () => {
+  await cleanupWorkspace(testWorkspace.id);
+});
+
+describe("POST /api/v1/transactional-email-templates", () => {
+  test("creates and publishes a template by default", async () => {
+    const request = post(
+      basePath(),
+      {
+        name: "Receipt v1",
+        uniqueSlug: "receipt-v1",
+        subject: "Your receipt",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.object).toBe("transactional_email_template");
+    expect(data.id).toBeDefined();
+    expect(data.uniqueSlug).toBe("receipt-v1");
+    expect(data.status).toBe("PUBLISHED");
+  });
+
+  test("creates a DRAFT when publish=false", async () => {
+    const request = post(
+      basePath(),
+      {
+        name: "Draft Template",
+        uniqueSlug: "draft-tpl",
+        subject: "Draft",
+        html: TRANSACTIONAL_HTML,
+        publish: false,
+      },
+      fullAccessApiKey.key,
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.status).toBe("DRAFT");
+  });
+
+  test("accepts HTML with only {{business_address}} (transactional compliance)", async () => {
+    const request = post(
+      basePath(),
+      {
+        name: "Minimal Compliance",
+        uniqueSlug: "minimal-compliance",
+        subject: "Ok",
+        html: `<p>Hi</p><p>{{business_address}}</p>`,
+      },
+      fullAccessApiKey.key,
+    );
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+  });
+
+  test("rejects HTML missing {{business_address}}", async () => {
+    const request = post(
+      basePath(),
+      {
+        name: "No address",
+        uniqueSlug: "no-address",
+        subject: "Nope",
+        html: `<p>Hello</p>`,
+      },
+      fullAccessApiKey.key,
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.message).toMatch(/business_address/);
+  });
+
+  test("rejects duplicate uniqueSlug", async () => {
+    const first = post(
+      basePath(),
+      {
+        name: "Slug collide",
+        uniqueSlug: "slug-collide",
+        subject: "First",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+    await POST(first);
+
+    const second = post(
+      basePath(),
+      {
+        name: "Slug collide 2",
+        uniqueSlug: "slug-collide",
+        subject: "Second",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+    const response = await POST(second);
+    expect(response.status).toBe(409);
+  });
+
+  test("requires manage:templates scope", async () => {
+    const readOnlyKey = await createTestApiKey({
+      workspaceId: testWorkspace.id,
+      scopes: ["read:templates"],
+    });
+
+    const request = post(
+      basePath(),
+      {
+        name: "Scope test",
+        uniqueSlug: "scope-test",
+        subject: "Scope",
+        html: TRANSACTIONAL_HTML,
+      },
+      readOnlyKey.key,
+    );
+
+    const response = await POST(request);
+    expect([401, 403]).toContain(response.status);
+  });
+});
+
+describe("GET /api/v1/transactional-email-templates", () => {
+  test("lists templates with pagination shape", async () => {
+    const request = get(basePath(), fullAccessApiKey.key);
+    const response = await LIST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.object).toBe("transactional_email_template_list");
+    expect(Array.isArray(data.data)).toBe(true);
+  });
+});
+
+describe("GET/PUT/DELETE /api/v1/transactional-email-templates/[id]", () => {
+  async function createDraft(slug: string) {
+    const request = post(
+      basePath(),
+      {
+        name: `Draft ${slug}`,
+        uniqueSlug: slug,
+        subject: "Draft",
+        html: TRANSACTIONAL_HTML,
+        publish: false,
+      },
+      fullAccessApiKey.key,
+    );
+    const res = await POST(request);
+    return (await res.json()).id as string;
+  }
+
+  test("gets a template", async () => {
+    const id = await createDraft("draft-get");
+    const request = get(basePath(`/${id}`), fullAccessApiKey.key);
+    const response = await GET(request, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.id).toBe(id);
+    expect(data.html).toContain("Receipt");
+    expect(data.variables).toContain("firstName");
+  });
+
+  test("updates a DRAFT template", async () => {
+    const id = await createDraft("draft-update");
+    const request = put(
+      basePath(`/${id}`),
+      { html: UPDATED_HTML, subject: "Updated" },
+      fullAccessApiKey.key,
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    expect(response.status).toBe(200);
+
+    const getRes = await GET(get(basePath(`/${id}`), fullAccessApiKey.key), {
+      params: Promise.resolve({ templateId: id }),
+    });
+    const data = await getRes.json();
+    expect(data.subject).toBe("Updated");
+    expect(data.html).toContain("Updated Receipt");
+  });
+
+  test("rejects update of PUBLISHED template", async () => {
+    const createReq = post(
+      basePath(),
+      {
+        name: "Published",
+        uniqueSlug: "immutable-pub",
+        subject: "P",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+    const id = (await (await POST(createReq)).json()).id as string;
+
+    const request = put(
+      basePath(`/${id}`),
+      { subject: "cannot" },
+      fullAccessApiKey.key,
+    );
+    const response = await PUT(request, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  test("deletes a DRAFT template", async () => {
+    const id = await createDraft("draft-delete");
+    const request = del(basePath(`/${id}`), fullAccessApiKey.key);
+    const response = await DELETE(request, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("POST /api/v1/transactional-email-templates/[id]/publish", () => {
+  test("publishes a DRAFT template", async () => {
+    const createReq = post(
+      basePath(),
+      {
+        name: "To publish",
+        uniqueSlug: "to-publish",
+        subject: "Hi",
+        html: TRANSACTIONAL_HTML,
+        publish: false,
+      },
+      fullAccessApiKey.key,
+    );
+    const id = (await (await POST(createReq)).json()).id as string;
+
+    const publishReq = post(basePath(`/${id}/publish`), {}, fullAccessApiKey.key);
+    const response = await PUBLISH(publishReq, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    expect(response.status).toBe(200);
+
+    const getRes = await GET(get(basePath(`/${id}`), fullAccessApiKey.key), {
+      params: Promise.resolve({ templateId: id }),
+    });
+    const data = await getRes.json();
+    expect(data.status).toBe("PUBLISHED");
+    expect(data.publishedAt).toBeTruthy();
+  });
+});
+
+describe("GET /api/v1/transactional-email-templates/[id]/preview", () => {
+  test("returns substituted HTML", async () => {
+    const createReq = post(
+      basePath(),
+      {
+        name: "Preview me",
+        uniqueSlug: "preview-me",
+        subject: "P",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+    const id = (await (await POST(createReq)).json()).id as string;
+
+    const request = get(basePath(`/${id}/preview`), fullAccessApiKey.key);
+    const response = await PREVIEW(request, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(data.hasContent).toBe(true);
+    expect(data.html).toBeTruthy();
+  });
+});
+
+describe("Versions", () => {
+  test("creates + lists versions", async () => {
+    const createReq = post(
+      basePath(),
+      {
+        name: "Versioned",
+        uniqueSlug: "versioned",
+        subject: "V1",
+        html: TRANSACTIONAL_HTML,
+      },
+      fullAccessApiKey.key,
+    );
+    const id = (await (await POST(createReq)).json()).id as string;
+
+    const createVersionReq = post(
+      basePath(`/${id}/versions`),
+      {},
+      fullAccessApiKey.key,
+    );
+    const vResponse = await CREATE_VERSION(createVersionReq, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    expect(vResponse.status).toBe(201);
+
+    const listReq = get(basePath(`/${id}/versions`), fullAccessApiKey.key);
+    const listResponse = await LIST_VERSIONS(listReq, {
+      params: Promise.resolve({ templateId: id }),
+    });
+    const listData = await listResponse.json();
+    expect(listResponse.status).toBe(200);
+    expect(Array.isArray(listData.data)).toBe(true);
+    expect(listData.data.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/tests/utils/api-keys.ts
+++ b/apps/web/tests/utils/api-keys.ts
@@ -128,6 +128,8 @@ export async function createFullAccessApiKey(
       "delete:broadcasts",
       "read:emails",
       "write:emails",
+      "read:templates",
+      "manage:templates",
       "smtp:send",
     ],
   });

--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -53,8 +53,9 @@ type Client struct {
 	Broadcasts        BroadcastsSvc
 	Automations       AutomationsSvc
 	Events            EventsSvc
-	MarketingEmails   MarketingEmailsSvc
-	Inbox             InboxSvc
+	MarketingEmails             MarketingEmailsSvc
+	Inbox                       InboxSvc
+	TransactionalEmailTemplates TransactionalEmailTemplatesSvc
 }
 
 // NewClient is the default client constructor
@@ -92,6 +93,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Events = &EventsSvcImpl{client: c}
 	c.MarketingEmails = &MarketingEmailsSvcImpl{client: c}
 	c.Inbox = &InboxSvcImpl{client: c}
+	c.TransactionalEmailTemplates = &TransactionalEmailTemplatesSvcImpl{client: c}
 
 	return c
 }

--- a/sdks/go/cmd/kibamail/cmd/marketing_emails.go
+++ b/sdks/go/cmd/kibamail/cmd/marketing_emails.go
@@ -1,10 +1,31 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/kibamail/cli/internal"
 	kibamail "github.com/kibamail/kibamail/sdks/go"
 	"github.com/spf13/cobra"
 )
+
+// resolveHtmlFlags returns the HTML body, preferring --html-file when
+// set. Returns an error if both --html and --html-file are provided.
+func resolveHtmlFlags(cmd *cobra.Command) (string, error) {
+	inline, _ := cmd.Flags().GetString("html")
+	path, _ := cmd.Flags().GetString("html-file")
+	if inline != "" && path != "" {
+		return "", fmt.Errorf("--html and --html-file are mutually exclusive")
+	}
+	if path != "" {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read --html-file %q: %w", path, err)
+		}
+		return string(b), nil
+	}
+	return inline, nil
+}
 
 func newMarketingEmailsCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -40,7 +61,10 @@ func newMarketingEmailsCreateCmd() *cobra.Command {
 			if v, _ := cmd.Flags().GetString("preview-text"); v != "" {
 				req.PreviewText = v
 			}
-			if v, _ := cmd.Flags().GetString("html"); v != "" {
+			if v, err := resolveHtmlFlags(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			} else if v != "" {
 				req.Html = v
 			}
 			if v, _ := cmd.Flags().GetString("sender-identity-id"); v != "" {
@@ -75,7 +99,8 @@ func newMarketingEmailsCreateCmd() *cobra.Command {
 	cmd.Flags().String("name", "", "Marketing email name [required]")
 	cmd.Flags().String("subject", "", "Email subject")
 	cmd.Flags().String("preview-text", "", "Preview text")
-	cmd.Flags().String("html", "", "HTML body")
+	cmd.Flags().String("html", "", "HTML body (inline)")
+	cmd.Flags().String("html-file", "", "Path to a file containing the HTML body (UTF-8)")
 	cmd.Flags().String("sender-identity-id", "", "Sender identity ID")
 	cmd.Flags().String("reply-to-identity-id", "", "Reply-to identity ID")
 	cmd.Flags().String("type", "", "Email type")
@@ -154,7 +179,10 @@ func newMarketingEmailsUpdateCmd() *cobra.Command {
 			if v, _ := cmd.Flags().GetString("preview-text"); v != "" {
 				req.PreviewText = v
 			}
-			if v, _ := cmd.Flags().GetString("html"); v != "" {
+			if v, err := resolveHtmlFlags(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			} else if v != "" {
 				req.Html = v
 			}
 			if v, _ := cmd.Flags().GetString("sender-identity-id"); v != "" {
@@ -189,7 +217,8 @@ func newMarketingEmailsUpdateCmd() *cobra.Command {
 	cmd.Flags().String("name", "", "Marketing email name")
 	cmd.Flags().String("subject", "", "Email subject")
 	cmd.Flags().String("preview-text", "", "Preview text")
-	cmd.Flags().String("html", "", "HTML body")
+	cmd.Flags().String("html", "", "HTML body (inline)")
+	cmd.Flags().String("html-file", "", "Path to a file containing the HTML body (UTF-8)")
 	cmd.Flags().String("sender-identity-id", "", "Sender identity ID")
 	cmd.Flags().String("reply-to-identity-id", "", "Reply-to identity ID")
 	cmd.Flags().String("type", "", "Email type")

--- a/sdks/go/cmd/kibamail/cmd/root.go
+++ b/sdks/go/cmd/kibamail/cmd/root.go
@@ -64,6 +64,7 @@ func NewRootCmd(version, commit string) *cobra.Command {
 	rootCmd.AddCommand(newDomainsCmd())
 	rootCmd.AddCommand(newBroadcastsCmd())
 	rootCmd.AddCommand(newMarketingEmailsCmd())
+	rootCmd.AddCommand(newTransactionalEmailTemplatesCmd())
 	rootCmd.AddCommand(newVersionCmd(version, commit))
 
 	return rootCmd

--- a/sdks/go/cmd/kibamail/cmd/transactional_email_templates.go
+++ b/sdks/go/cmd/kibamail/cmd/transactional_email_templates.go
@@ -1,0 +1,350 @@
+package cmd
+
+import (
+	"github.com/kibamail/cli/internal"
+	kibamail "github.com/kibamail/kibamail/sdks/go"
+	"github.com/spf13/cobra"
+)
+
+func newTransactionalEmailTemplatesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "transactional-email-templates",
+		Aliases: []string{"transactional-templates", "tet"},
+		Short:   "Manage transactional email templates (HTML-only)",
+		Long: `Manage the HTML-only transactional email templates used by
+POST /v1/emails/send's template resolver.
+
+All mutating subcommands accept --html or --html-file. The --html-file
+form is strongly recommended for anything non-trivial — it avoids shell
+quoting pitfalls with Handlebars ({{ ... }}), inline CSS, and multi-line
+bodies.`,
+	}
+	cmd.AddCommand(
+		newTETCreateCmd(),
+		newTETListCmd(),
+		newTETShowCmd(),
+		newTETUpdateCmd(),
+		newTETDeleteCmd(),
+		newTETPublishCmd(),
+		newTETPreviewCmd(),
+		newTETCreateVersionCmd(),
+		newTETListVersionsCmd(),
+	)
+	return cmd
+}
+
+func newTETCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a transactional email template",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			html, err := resolveHtmlFlags(cmd)
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			name, _ := cmd.Flags().GetString("name")
+			slug, _ := cmd.Flags().GetString("slug")
+			subject, _ := cmd.Flags().GetString("subject")
+			req := &kibamail.CreateTransactionalEmailTemplateRequest{
+				Name:       name,
+				UniqueSlug: slug,
+				Subject:    subject,
+				Html:       html,
+			}
+			if v, _ := cmd.Flags().GetString("description"); v != "" {
+				req.Description = v
+			}
+			if v, _ := cmd.Flags().GetString("preview-text"); v != "" {
+				req.PreviewText = v
+			}
+			if v, _ := cmd.Flags().GetString("sender-identity-id"); v != "" {
+				req.SenderIdentityId = v
+			}
+			if v, _ := cmd.Flags().GetString("reply-to-identity-id"); v != "" {
+				req.ReplyToIdentityId = v
+			}
+			if cmd.Flags().Changed("track-clicks") {
+				v, _ := cmd.Flags().GetBool("track-clicks")
+				req.TrackClicks = &v
+			}
+			if cmd.Flags().Changed("track-opens") {
+				v, _ := cmd.Flags().GetBool("track-opens")
+				req.TrackOpens = &v
+			}
+			if cmd.Flags().Changed("publish") {
+				v, _ := cmd.Flags().GetBool("publish")
+				req.Publish = &v
+			}
+			result, err := Client.TransactionalEmailTemplates.Create(req)
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if internal.IsJSON(cmd) {
+				return internal.PrintResult(cmd, result)
+			}
+			cmd.Printf("Created transactional email template %s (slug=%s, status=%s)\n", result.ID, result.UniqueSlug, result.Status)
+			return nil
+		},
+	}
+	cmd.Flags().String("name", "", "Template name [required]")
+	cmd.Flags().String("slug", "", "Unique slug — used by /v1/emails/send template.id [required]")
+	cmd.Flags().String("subject", "", "Email subject [required]")
+	cmd.Flags().String("description", "", "Template description")
+	cmd.Flags().String("preview-text", "", "Preview text (inbox teaser)")
+	cmd.Flags().String("html", "", "HTML body (inline)")
+	cmd.Flags().String("html-file", "", "Path to a file containing the HTML body (UTF-8)")
+	cmd.Flags().String("sender-identity-id", "", "Default sender identity ID")
+	cmd.Flags().String("reply-to-identity-id", "", "Default reply-to identity ID")
+	cmd.Flags().Bool("track-clicks", true, "Track link clicks")
+	cmd.Flags().Bool("track-opens", true, "Track opens")
+	cmd.Flags().Bool("publish", true, "Publish on create (pass --publish=false for a DRAFT)")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("slug")
+	_ = cmd.MarkFlagRequired("subject")
+	return cmd
+}
+
+func newTETListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List transactional email templates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			opts := &kibamail.ListOptions{}
+			if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
+				opts.Limit = &limit
+			}
+			if after, _ := cmd.Flags().GetString("after"); after != "" {
+				opts.After = &after
+			}
+			result, err := Client.TransactionalEmailTemplates.List(opts)
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			return internal.PrintResult(cmd, result)
+		},
+	}
+	cmd.Flags().Int("limit", 0, "Maximum number of results")
+	cmd.Flags().String("after", "", "Cursor for next page")
+	return cmd
+}
+
+func newTETShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show a transactional email template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			result, err := Client.TransactionalEmailTemplates.Get(args[0])
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			return internal.PrintResult(cmd, result)
+		},
+	}
+}
+
+func newTETUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a DRAFT transactional email template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			html, err := resolveHtmlFlags(cmd)
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			req := &kibamail.UpdateTransactionalEmailTemplateRequest{}
+			if v, _ := cmd.Flags().GetString("name"); v != "" {
+				req.Name = v
+			}
+			if v, _ := cmd.Flags().GetString("slug"); v != "" {
+				req.UniqueSlug = v
+			}
+			if v, _ := cmd.Flags().GetString("subject"); v != "" {
+				req.Subject = v
+			}
+			if cmd.Flags().Changed("description") {
+				v, _ := cmd.Flags().GetString("description")
+				req.Description = &v
+			}
+			if cmd.Flags().Changed("preview-text") {
+				v, _ := cmd.Flags().GetString("preview-text")
+				req.PreviewText = &v
+			}
+			if html != "" {
+				req.Html = html
+			}
+			if cmd.Flags().Changed("sender-identity-id") {
+				v, _ := cmd.Flags().GetString("sender-identity-id")
+				req.SenderIdentityId = &v
+			}
+			if cmd.Flags().Changed("reply-to-identity-id") {
+				v, _ := cmd.Flags().GetString("reply-to-identity-id")
+				req.ReplyToIdentityId = &v
+			}
+			if cmd.Flags().Changed("track-clicks") {
+				v, _ := cmd.Flags().GetBool("track-clicks")
+				req.TrackClicks = &v
+			}
+			if cmd.Flags().Changed("track-opens") {
+				v, _ := cmd.Flags().GetBool("track-opens")
+				req.TrackOpens = &v
+			}
+			result, err := Client.TransactionalEmailTemplates.Update(args[0], req)
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if internal.IsJSON(cmd) {
+				return internal.PrintResult(cmd, result)
+			}
+			cmd.Printf("Updated transactional email template %s\n", result.ID)
+			return nil
+		},
+	}
+	cmd.Flags().String("name", "", "Template name")
+	cmd.Flags().String("slug", "", "Unique slug")
+	cmd.Flags().String("subject", "", "Email subject")
+	cmd.Flags().String("description", "", "Template description")
+	cmd.Flags().String("preview-text", "", "Preview text")
+	cmd.Flags().String("html", "", "HTML body (inline)")
+	cmd.Flags().String("html-file", "", "Path to a file containing the HTML body (UTF-8)")
+	cmd.Flags().String("sender-identity-id", "", "Default sender identity ID")
+	cmd.Flags().String("reply-to-identity-id", "", "Default reply-to identity ID")
+	cmd.Flags().Bool("track-clicks", true, "Track link clicks")
+	cmd.Flags().Bool("track-opens", true, "Track opens")
+	return cmd
+}
+
+func newTETDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a DRAFT transactional email template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if err := Client.TransactionalEmailTemplates.Delete(args[0]); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if internal.IsJSON(cmd) {
+				cmd.Printf(`{"deleted":true,"id":"%s"}`+"\n", args[0])
+			} else {
+				cmd.Printf("Deleted transactional email template %s\n", args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func newTETPublishCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "publish <id>",
+		Short: "Publish a DRAFT transactional email template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			result, err := Client.TransactionalEmailTemplates.Publish(args[0])
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if internal.IsJSON(cmd) {
+				return internal.PrintResult(cmd, result)
+			}
+			cmd.Printf("Published transactional email template %s\n", result.ID)
+			return nil
+		},
+	}
+}
+
+func newTETPreviewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "preview <id>",
+		Short: "Preview a transactional email template with SAMPLE_VARIABLES",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			result, err := Client.TransactionalEmailTemplates.Preview(args[0])
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			return internal.PrintResult(cmd, result)
+		},
+	}
+}
+
+func newTETCreateVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create-version <id>",
+		Short: "Create a new DRAFT version from a published template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			result, err := Client.TransactionalEmailTemplates.CreateVersion(args[0])
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			if internal.IsJSON(cmd) {
+				return internal.PrintResult(cmd, result)
+			}
+			cmd.Printf("Created version %s\n", result.ID)
+			return nil
+		},
+	}
+}
+
+func newTETListVersionsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-versions <id>",
+		Short: "List all versions of a transactional email template",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireClient(cmd); err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			result, err := Client.TransactionalEmailTemplates.ListVersions(args[0])
+			if err != nil {
+				internal.HandleError(cmd, err)
+				return nil
+			}
+			return internal.PrintResult(cmd, result)
+		},
+	}
+}

--- a/sdks/go/errors.go
+++ b/sdks/go/errors.go
@@ -211,6 +211,19 @@ var (
 	ErrFailedToCreateInboxStatsRequest              = errors.New("[ERROR]: Failed to create Inbox.Stats request")
 )
 
+// TransactionalEmailTemplatesSvc errors
+var (
+	ErrFailedToCreateTransactionalEmailTemplatesCreateRequest        = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Create request")
+	ErrFailedToCreateTransactionalEmailTemplatesListRequest          = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.List request")
+	ErrFailedToCreateTransactionalEmailTemplatesGetRequest           = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Get request")
+	ErrFailedToCreateTransactionalEmailTemplatesUpdateRequest        = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Update request")
+	ErrFailedToCreateTransactionalEmailTemplatesDeleteRequest        = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Delete request")
+	ErrFailedToCreateTransactionalEmailTemplatesPublishRequest       = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Publish request")
+	ErrFailedToCreateTransactionalEmailTemplatesPreviewRequest       = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.Preview request")
+	ErrFailedToCreateTransactionalEmailTemplatesCreateVersionRequest = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.CreateVersion request")
+	ErrFailedToCreateTransactionalEmailTemplatesListVersionsRequest  = errors.New("[ERROR]: Failed to create TransactionalEmailTemplates.ListVersions request")
+)
+
 // handleError tries to handle errors based on HTTP status codes.
 // It preserves the full structured error response from the API.
 func handleError(resp *http.Response) error {

--- a/sdks/go/transactional_email_templates.go
+++ b/sdks/go/transactional_email_templates.go
@@ -1,0 +1,307 @@
+package kibamail
+
+import (
+	"context"
+	"net/http"
+)
+
+// CreateTransactionalEmailTemplateRequest is the request object for creating
+// a transactional email template from raw HTML.
+//
+// `Publish` defaults to true on the server side — set it to a pointer to
+// false via Publish(false) if you want to create a DRAFT instead.
+type CreateTransactionalEmailTemplateRequest struct {
+	Name              string               `json:"name"`
+	Description       string               `json:"description,omitempty"`
+	UniqueSlug        string               `json:"uniqueSlug"`
+	Subject           string               `json:"subject"`
+	PreviewText       string               `json:"previewText,omitempty"`
+	Html              string               `json:"html"`
+	SenderIdentityId  string               `json:"senderIdentityId,omitempty"`
+	ReplyToIdentityId string               `json:"replyToIdentityId,omitempty"`
+	TrackClicks       *bool                `json:"trackClicks,omitempty"`
+	TrackOpens        *bool                `json:"trackOpens,omitempty"`
+	Variables         []VariableDefinition `json:"variables,omitempty"`
+	Publish           *bool                `json:"publish,omitempty"`
+}
+
+// UpdateTransactionalEmailTemplateRequest is the request object for
+// editing a DRAFT transactional email template.
+type UpdateTransactionalEmailTemplateRequest struct {
+	Name              string               `json:"name,omitempty"`
+	Description       *string              `json:"description,omitempty"`
+	UniqueSlug        string               `json:"uniqueSlug,omitempty"`
+	Subject           string               `json:"subject,omitempty"`
+	PreviewText       *string              `json:"previewText,omitempty"`
+	Html              string               `json:"html,omitempty"`
+	SenderIdentityId  *string              `json:"senderIdentityId,omitempty"`
+	ReplyToIdentityId *string              `json:"replyToIdentityId,omitempty"`
+	TrackClicks       *bool                `json:"trackClicks,omitempty"`
+	TrackOpens        *bool                `json:"trackOpens,omitempty"`
+	Variables         []VariableDefinition `json:"variables,omitempty"`
+}
+
+// VariableDefinition describes a typed variable used by a template.
+type VariableDefinition struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"` // "text" or "number"
+}
+
+// TransactionalEmailTemplate is the full template representation returned
+// by GET /v1/transactional-email-templates/{id}.
+type TransactionalEmailTemplate struct {
+	Object              string               `json:"object"`
+	ID                  string               `json:"id"`
+	Name                string               `json:"name"`
+	Description         string               `json:"description"`
+	UniqueSlug          string               `json:"uniqueSlug"`
+	Status              string               `json:"status"`
+	Version             int                  `json:"version"`
+	ParentID            string               `json:"parentId"`
+	Subject             string               `json:"subject"`
+	PreviewText         string               `json:"previewText"`
+	Html                string               `json:"html"`
+	Text                string               `json:"text"`
+	Variables           []string             `json:"variables"`
+	VariableDefinitions []VariableDefinition `json:"variableDefinitions"`
+	SenderIdentityId    string               `json:"senderIdentityId"`
+	ReplyToIdentityId   string               `json:"replyToIdentityId"`
+	TrackClicks         bool                 `json:"trackClicks"`
+	TrackOpens          bool                 `json:"trackOpens"`
+	PublishedAt         string               `json:"publishedAt"`
+	CreatedAt           string               `json:"createdAt"`
+	UpdatedAt           string               `json:"updatedAt"`
+}
+
+// TransactionalEmailTemplateListItem is a compact row in list responses.
+type TransactionalEmailTemplateListItem = TransactionalEmailTemplate
+
+// ListTransactionalEmailTemplatesResponse is the response from List.
+type ListTransactionalEmailTemplatesResponse struct {
+	Object      string                               `json:"object"`
+	Data        []TransactionalEmailTemplateListItem `json:"data"`
+	HasMore     bool                                 `json:"hasMore"`
+	HasPrevious bool                                 `json:"hasPrevious"`
+}
+
+// TransactionalEmailTemplateResponse is the minimal response returned from
+// write operations (create / update / publish / delete).
+type TransactionalEmailTemplateResponse struct {
+	Object     string `json:"object"`
+	ID         string `json:"id"`
+	UniqueSlug string `json:"uniqueSlug,omitempty"`
+	Status     string `json:"status,omitempty"`
+}
+
+// TransactionalEmailTemplatePreview is the response from Preview.
+type TransactionalEmailTemplatePreview struct {
+	Object     string `json:"object"`
+	Html       string `json:"html"`
+	HasContent bool   `json:"hasContent"`
+}
+
+// TransactionalEmailTemplateVersion is a single row returned by the
+// versions list endpoint.
+type TransactionalEmailTemplateVersion struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Version     int    `json:"version"`
+	Status      string `json:"status"`
+	IsLive      bool   `json:"isLive"`
+	PublishedAt string `json:"publishedAt"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+// ListTransactionalEmailTemplateVersionsResponse is the response from
+// the versions list endpoint.
+type ListTransactionalEmailTemplateVersionsResponse struct {
+	Object      string                              `json:"object"`
+	Data        []TransactionalEmailTemplateVersion `json:"data"`
+	HasMore     bool                                `json:"hasMore"`
+	HasPrevious bool                                `json:"hasPrevious"`
+}
+
+// TransactionalEmailTemplatesSvc provides access to the
+// /v1/transactional-email-templates resource.
+type TransactionalEmailTemplatesSvc interface {
+	Create(params *CreateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error)
+	CreateWithContext(ctx context.Context, params *CreateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error)
+
+	List(params *ListOptions) (*ListTransactionalEmailTemplatesResponse, error)
+	ListWithContext(ctx context.Context, params *ListOptions) (*ListTransactionalEmailTemplatesResponse, error)
+
+	Get(templateId string) (*TransactionalEmailTemplate, error)
+	GetWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplate, error)
+
+	Update(templateId string, params *UpdateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error)
+	UpdateWithContext(ctx context.Context, templateId string, params *UpdateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error)
+
+	Delete(templateId string) error
+	DeleteWithContext(ctx context.Context, templateId string) error
+
+	Publish(templateId string) (*TransactionalEmailTemplateResponse, error)
+	PublishWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplateResponse, error)
+
+	Preview(templateId string) (*TransactionalEmailTemplatePreview, error)
+	PreviewWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplatePreview, error)
+
+	CreateVersion(templateId string) (*TransactionalEmailTemplateResponse, error)
+	CreateVersionWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplateResponse, error)
+
+	ListVersions(templateId string) (*ListTransactionalEmailTemplateVersionsResponse, error)
+	ListVersionsWithContext(ctx context.Context, templateId string) (*ListTransactionalEmailTemplateVersionsResponse, error)
+}
+
+// TransactionalEmailTemplatesSvcImpl is the concrete implementation.
+type TransactionalEmailTemplatesSvcImpl struct {
+	client *Client
+}
+
+const transactionalEmailTemplatesPath = "v1/transactional-email-templates"
+
+func (s *TransactionalEmailTemplatesSvcImpl) Create(params *CreateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) CreateWithContext(ctx context.Context, params *CreateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, transactionalEmailTemplatesPath, params)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesCreateRequest
+	}
+	resp := new(TransactionalEmailTemplateResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) List(params *ListOptions) (*ListTransactionalEmailTemplatesResponse, error) {
+	return s.ListWithContext(context.Background(), params)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) ListWithContext(ctx context.Context, params *ListOptions) (*ListTransactionalEmailTemplatesResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, transactionalEmailTemplatesPath+buildPaginationQuery(params), nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesListRequest
+	}
+	resp := new(ListTransactionalEmailTemplatesResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) Get(templateId string) (*TransactionalEmailTemplate, error) {
+	return s.GetWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) GetWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplate, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, transactionalEmailTemplatesPath+"/"+templateId, nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesGetRequest
+	}
+	template := new(TransactionalEmailTemplate)
+	if _, err := s.client.Perform(req, template); err != nil {
+		return nil, err
+	}
+	return template, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) Update(templateId string, params *UpdateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error) {
+	return s.UpdateWithContext(context.Background(), templateId, params)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) UpdateWithContext(ctx context.Context, templateId string, params *UpdateTransactionalEmailTemplateRequest) (*TransactionalEmailTemplateResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPut, transactionalEmailTemplatesPath+"/"+templateId, params)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesUpdateRequest
+	}
+	resp := new(TransactionalEmailTemplateResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) Delete(templateId string) error {
+	return s.DeleteWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) DeleteWithContext(ctx context.Context, templateId string) error {
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, transactionalEmailTemplatesPath+"/"+templateId, nil)
+	if err != nil {
+		return ErrFailedToCreateTransactionalEmailTemplatesDeleteRequest
+	}
+	_, err = s.client.Perform(req, nil)
+	return err
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) Publish(templateId string) (*TransactionalEmailTemplateResponse, error) {
+	return s.PublishWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) PublishWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplateResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, transactionalEmailTemplatesPath+"/"+templateId+"/publish", nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesPublishRequest
+	}
+	resp := new(TransactionalEmailTemplateResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) Preview(templateId string) (*TransactionalEmailTemplatePreview, error) {
+	return s.PreviewWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) PreviewWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplatePreview, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, transactionalEmailTemplatesPath+"/"+templateId+"/preview", nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesPreviewRequest
+	}
+	preview := new(TransactionalEmailTemplatePreview)
+	if _, err := s.client.Perform(req, preview); err != nil {
+		return nil, err
+	}
+	return preview, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) CreateVersion(templateId string) (*TransactionalEmailTemplateResponse, error) {
+	return s.CreateVersionWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) CreateVersionWithContext(ctx context.Context, templateId string) (*TransactionalEmailTemplateResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, transactionalEmailTemplatesPath+"/"+templateId+"/versions", nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesCreateVersionRequest
+	}
+	resp := new(TransactionalEmailTemplateResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) ListVersions(templateId string) (*ListTransactionalEmailTemplateVersionsResponse, error) {
+	return s.ListVersionsWithContext(context.Background(), templateId)
+}
+
+func (s *TransactionalEmailTemplatesSvcImpl) ListVersionsWithContext(ctx context.Context, templateId string) (*ListTransactionalEmailTemplateVersionsResponse, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, transactionalEmailTemplatesPath+"/"+templateId+"/versions", nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTransactionalEmailTemplatesListVersionsRequest
+	}
+	resp := new(ListTransactionalEmailTemplateVersionsResponse)
+	if _, err := s.client.Perform(req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// BoolPtr returns a pointer to b — helpful for the optional *bool fields
+// in the request structs (e.g. Publish, TrackClicks, TrackOpens).
+func BoolPtr(b bool) *bool { return &b }

--- a/skills/kibamail-go-sdk/SKILL.md
+++ b/skills/kibamail-go-sdk/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: kibamail-go-sdk
+description: >
+  Integrate the Kibamail Go SDK into Go backend applications. Use this skill
+  whenever the user imports `github.com/kibamail/kibamail/sdks/go`, calls
+  `kibamail.NewClient(...)`, or asks about sending emails, managing contacts,
+  forms, broadcasts, automations, or any email marketing feature from Go code.
+  Also trigger when the user mentions the Kibamail Go SDK, the Kibamail API
+  from Go, or wants to add transactional email / marketing automation to a Go
+  service (Gin, Echo, Fiber, chi, net/http, worker, or CLI).
+---
+
+# Kibamail Go SDK
+
+The `github.com/kibamail/kibamail/sdks/go` module provides a typed Go client for the Kibamail API. It handles authentication, URL building, JSON marshaling, and structured error parsing. Zero runtime dependencies.
+
+**Current version:** `v0.1.0` · **Go:** `1.23+`
+
+## Installation
+
+```bash
+go get github.com/kibamail/kibamail/sdks/go@latest
+```
+
+Import as:
+
+```go
+import kibamail "github.com/kibamail/kibamail/sdks/go"
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "os"
+    "time"
+
+    kibamail "github.com/kibamail/kibamail/sdks/go"
+)
+
+func main() {
+    kb := kibamail.NewClient(os.Getenv("KIBAMAIL_API_KEY"))
+
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+
+    res, err := kb.Contacts.CreateWithContext(ctx, &kibamail.CreateContactRequest{
+        Email:     "user@example.com",
+        FirstName: "Jane",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    log.Println("contact id:", res.ID)
+}
+```
+
+## Client Initialization
+
+### Default (reads `KIBAMAIL_BASE_URL` from env, defaults to production)
+
+```go
+kb := kibamail.NewClient(os.Getenv("KIBAMAIL_API_KEY"))
+```
+
+### Custom HTTP client (timeouts, retries, tracing, proxy)
+
+```go
+httpClient := &http.Client{
+    Timeout: 15 * time.Second,
+    Transport: &http.Transport{
+        MaxIdleConns:        200,
+        MaxIdleConnsPerHost: 50,
+        IdleConnTimeout:     90 * time.Second,
+    },
+}
+kb := kibamail.NewCustomClient(httpClient, os.Getenv("KIBAMAIL_API_KEY"))
+```
+
+### Staging / self-hosted base URL
+
+```go
+// Option A: env var (read at client construction)
+os.Setenv("KIBAMAIL_BASE_URL", "https://api.staging.kibamail.com")
+kb := kibamail.NewClient(apiKey)
+
+// Option B: override after construction
+kb := kibamail.NewClient(apiKey)
+kb.BaseURL, _ = url.Parse("https://api.staging.kibamail.com/")
+```
+
+## Context & Method Variants
+
+Every method has two forms:
+
+| Form | When to use |
+|---|---|
+| `Client.Emails.Send(req)` | Scripts, CLIs, short-lived jobs. Uses `context.Background()`. |
+| `Client.Emails.SendWithContext(ctx, req)` | **All server code.** Always pass the request-scoped `ctx`. |
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+    res, err := kb.Emails.SendWithContext(r.Context(), &kibamail.SendEmailRequest{...})
+    // ...
+}
+```
+
+## Client is Goroutine-Safe — Share One
+
+Create **one** `*kibamail.Client` per process. Inject it as a dependency. Do not construct a new client per request — it defeats HTTP connection pooling.
+
+```go
+// Wire at startup
+type App struct { KB *kibamail.Client }
+
+func NewApp() *App {
+    return &App{KB: kibamail.NewClient(os.Getenv("KIBAMAIL_API_KEY"))}
+}
+```
+
+## Available Services
+
+Every resource is exposed as a typed service on `*kibamail.Client`:
+
+| Service | Field | Description |
+|---|---|---|
+| Contacts | `kb.Contacts` | CRUD + cursor pagination + filter search |
+| Contact Properties | `kb.ContactProperties` | Custom contact field definitions |
+| Topics | `kb.Topics` | Interest lists contacts can subscribe to |
+| Segments | `kb.Segments` | Dynamic contact groups |
+| Forms | `kb.Forms` | Opt-in forms, deploy assets, versioning |
+| Emails | `kb.Emails` | Transactional send + introspection |
+| Broadcasts | `kb.Broadcasts` | One-off marketing campaigns |
+| Marketing Emails | `kb.MarketingEmails` | Reusable campaign/template HTML |
+| Automations | `kb.Automations` | Trigger-driven workflows |
+| Domains | `kb.Domains` | Sending domain + DNS verification |
+| Inbox | `kb.Inbox` | Inbound mail / conversation threading |
+| Events | `kb.Events` | Custom analytics events |
+| API Keys | `kb.ApiKeys` | API key administration |
+
+## Response & Error Handling
+
+Every method returns `(*T, error)`. On success `err == nil`; on failure `err` wraps one of two typed errors:
+
+```go
+_, err := kb.Contacts.CreateWithContext(ctx, req)
+switch {
+case err == nil:
+    // success
+
+case errors.Is(err, kibamail.ErrRateLimit):
+    var rl *kibamail.RateLimitError
+    errors.As(err, &rl)
+    // honor rl.RetryAfter (seconds), back off, retry
+
+default:
+    var apiErr *kibamail.APIError
+    if errors.As(err, &apiErr) {
+        // apiErr.StatusCode, apiErr.Code, apiErr.Message,
+        // apiErr.Hint, apiErr.RequestID, apiErr.ValidationErrors
+        for _, v := range apiErr.ValidationErrors {
+            log.Printf("  %s: %s", v.Field, v.Message)
+        }
+    } else {
+        // transport error (DNS, TLS, context cancellation)
+    }
+}
+```
+
+**Always log `apiErr.RequestID`** — support triages failed calls by that ID.
+
+### Retry policy
+
+| Condition | Retry? |
+|---|---|
+| `*RateLimitError` (429) | Yes — honor `RetryAfter` |
+| `500 / 502 / 503 / 504` | Yes — exponential backoff |
+| Transport error / `context.DeadlineExceeded` | Yes — small backoff |
+| `401 / 403` | No — rotate the key |
+| `400 / 422` validation errors | No — fix the request |
+| `409 *_already_exists` | No — treat as upsert-idempotent |
+
+The SDK does **not** auto-retry. Wrap your calls in a thin retry helper if needed.
+
+## Pagination
+
+List endpoints use cursor pagination. `ListOptions.Limit` max is 200.
+
+```go
+limit := 200
+var cursor *string
+
+for {
+    page, err := kb.Contacts.ListWithContext(ctx, &kibamail.ListOptions{
+        Limit: &limit,
+        After: cursor,
+    })
+    if err != nil { return err }
+    for _, c := range page.Data { /* process */ }
+    if !page.HasMore { break }
+    last := page.Data[len(page.Data)-1].ID
+    cursor = &last
+}
+```
+
+## Pointer Helper (ergonomics)
+
+The SDK uses `*string`, `*int`, `*bool` for optional fields so zero-values aren't accidentally sent. Define a generic pointer helper once:
+
+```go
+func ptr[T any](v T) *T { return &v }
+
+// usage
+kb.Emails.List(&kibamail.ListEmailsOptions{Limit: ptr(50), Status: ptr("DELIVERED")})
+```
+
+## Reference Files
+
+Load these on demand for detailed per-resource examples and production patterns:
+
+| File | When to read |
+|---|---|
+| `references/emails.md` | Sending transactional email, templates, attachments, batch, delivery introspection |
+| `references/contacts.md` | Create, update, search, upsert, status lifecycle, custom properties |
+| `references/forms.md` | Create forms, deploy HTML/assets, publish, versioning, double-opt-in |
+| `references/broadcasts.md` | One-off campaigns, segments/topics, scheduling, per-send stats |
+| `references/marketing-emails.md` | Reusable template CRUD, Handlebars variables, preview, stats |
+| `references/transactional-email-templates.md` | HTML-only transactional templates — create, version, publish, resolve from Emails.Send |
+| `references/automations.md` | Trigger types, manual trigger, versioning, dry-run simulate |
+| `references/other-resources.md` | Domains, Topics, Segments, ContactProperties, Events, Inbox, ApiKeys |
+| `references/integration-patterns.md` | net/http, Gin, Echo, Fiber, chi wiring + graceful shutdown |
+
+## Hard Requirements
+
+- **Always use `*WithContext` in server code.** The context-less variants are only for scripts.
+- **Reuse one `*Client`.** Injected via constructor, never created per request.
+- **Set an HTTP client `Timeout`.** The default has keep-alives but no top-level timeout — set 10–15s on the `*http.Client` you pass to `NewCustomClient` for production.
+- **Never embed the API key in code.** Read from env or secret manager.
+- **HTML email content:** for marketing/broadcast/transactional HTML, generate with a templating library (e.g. [`mjml-go`](https://github.com/Boostport/mjml), `html/template` + MJML) — don't hand-concatenate strings.
+- **Template compliance variables:** when sending via a marketing-email template, the template HTML must include `{{business_address}}`, `{{unsubscribe_url}}`, `{{terms_url}}`, `{{privacy_url}}`. Raw `html` sends are exempt.

--- a/skills/kibamail-go-sdk/references/automations.md
+++ b/skills/kibamail-go-sdk/references/automations.md
@@ -1,0 +1,113 @@
+# Automations — Go SDK Reference
+
+Service: `kb.Automations`. Source: `sdks/go/automations.go`. Automations are DAGs (nodes + edges) that run per-contact in response to a trigger. Author graphs in the dashboard; drive lifecycle and ad-hoc execution from Go.
+
+## Lifecycle
+
+```go
+// Create as draft — usually from the dashboard; API call shown for completeness.
+a, err := kb.Automations.CreateWithContext(ctx, &kibamail.CreateAutomationRequest{
+    Name:        "Post-signup welcome",
+    Description: "3-email drip over 7 days",
+    Trigger: &kibamail.AutomationTrigger{
+        Type: "form.submitted",
+        Config: &kibamail.AutomationTriggerConfig{FormId: "form_xyz"},
+    },
+    Nodes: nodes, // opaque — author in dashboard
+    Edges: edges,
+})
+
+kb.Automations.PublishWithContext(ctx, a.ID)  // activate
+kb.Automations.ArchiveWithContext(ctx, a.ID)  // pause — in-flight runs continue
+kb.Automations.DeleteWithContext(ctx, a.ID)   // hard delete (only if archived/draft)
+```
+
+## Trigger types
+
+| `Trigger.Type` | Required config |
+|---|---|
+| `form.submitted` | `FormId` |
+| `segment.entered` | `SegmentId` |
+| `segment.exited` | `SegmentId` |
+| `contact.created` | — |
+| `contact.updated` | — |
+| `contact.property.changed` | `PropertyName` |
+| `event.occurred` | `EventName` |
+| `email.engaged` | `EmailEngagementType` ("opened" or "clicked") |
+| `api` | — (fire manually via `Trigger()`) |
+
+## Manually trigger for a contact
+
+Useful when a business event isn't wired to a native trigger:
+
+```go
+_, err := kb.Automations.TriggerWithContext(ctx, a.ID, &kibamail.TriggerAutomationRequest{
+    ContactId: "ct_abc",
+    Metadata: map[string]interface{}{
+        "orderId": "ord_1",
+        "plan":    "pro",
+    },
+})
+```
+
+Metadata is injected into every node's render context and available as `{{ metadata.orderId }}` in template variables.
+
+- Triggers are **idempotent per contact per run** — double-calls in quick succession return the existing run, not a new one.
+- Keep `Metadata` < 4 KB. For large blobs, store on the contact as properties and reference those.
+
+## Dry-run with Simulate
+
+Preview the node path a contact would take — without sending emails or mutating state:
+
+```go
+sim, err := kb.Automations.SimulateWithContext(ctx, a.ID, &kibamail.SimulateAutomationRequest{
+    ContactId: "ct_abc",
+    Seed:      ptr(42), // deterministic for A/B decision nodes
+})
+```
+
+Or with a virtual contact that doesn't exist in the workspace:
+
+```go
+kb.Automations.SimulateWithContext(ctx, a.ID, &kibamail.SimulateAutomationRequest{
+    Contact: &kibamail.VirtualContact{
+        Email:      "virtual@example.com",
+        FirstName:  "Jane",
+        Properties: map[string]interface{}{"plan": "pro", "country": "US"},
+        Topics:     []string{"topic_a"},
+    },
+})
+```
+
+Use Simulate in CI before rolling out property/segment migrations that could change branching behavior.
+
+## Versioning
+
+Every substantive edit should create a new version — in-flight runs keep executing on the version they started on:
+
+```go
+kb.Automations.CreateVersionWithContext(ctx, a.ID, &kibamail.UpdateAutomationRequest{
+    Nodes: newNodes,
+    Edges: newEdges,
+})
+
+vs, _ := kb.Automations.ListVersionsWithContext(ctx, a.ID)
+// Each version has ParentId linking back to the root automation.
+```
+
+New trigger events always execute against the latest published version.
+
+## Listing
+
+```go
+kb.Automations.ListWithContext(ctx, &kibamail.ListAutomationsOptions{
+    Limit: ptr(25),
+    // filter fields — see sdks/go/automations.go for the struct
+})
+```
+
+## Operational notes
+
+- **Wait nodes hold state in Redis.** A 7-day delay keeps context for 7 days; don't bulk-trigger millions in an hour without capacity planning.
+- **Metadata passed to `Trigger` is per-run immutable.** Later trigger calls for the same contact+run won't update it.
+- **Segment-entered triggers fire on each entry.** If a contact leaves and re-enters a segment, the automation runs again. Use a deduplication node (or check on the contact) if you want once-only behavior.

--- a/skills/kibamail-go-sdk/references/broadcasts.md
+++ b/skills/kibamail-go-sdk/references/broadcasts.md
@@ -1,0 +1,119 @@
+# Broadcasts — Go SDK Reference
+
+Service: `kb.Broadcasts`. Source: `sdks/go/broadcasts.go`. Broadcasts are one-off marketing sends to a topic, segment, or explicit recipient list.
+
+## Two ways to send
+
+### A. Draft → review → send
+
+```go
+// 1. Create draft
+bc, err := kb.Broadcasts.CreateWithContext(ctx, &kibamail.CreateBroadcastRequest{
+    Name:    "April product update",
+    From:    "Product <updates@acme.com>",
+    ReplyTo: "hello@acme.com",
+    TopicId: "topic_product_updates", // or SegmentId
+    EmailContent: &kibamail.BroadcastEmailContent{
+        Subject:     "What's new in April",
+        PreviewText: "New flows, new reports.",
+        Html:        htmlBody,
+        Text:        plainFallback,
+    },
+})
+
+// 2. Revise (any number of times)
+kb.Broadcasts.UpdateWithContext(ctx, bc.ID, &kibamail.UpdateBroadcastRequest{
+    EmailContent: &kibamail.BroadcastEmailContent{
+        Subject: "April product update — revised",
+    },
+})
+
+// 3. Schedule (sends immediately when SendAt is past/absent via Send endpoint)
+kb.Broadcasts.SendWithContext(ctx, bc.ID)
+```
+
+### B. Create-and-send in one call
+
+```go
+res, err := kb.Broadcasts.CreateAndSendWithContext(ctx, &kibamail.CreateAndSendBroadcastRequest{
+    Name:    "Black Friday",
+    From:    "Deals <deals@acme.com>",
+    ReplyTo: "support@acme.com",
+    EmailContent: &kibamail.BroadcastEmailContent{
+        Subject: "48h only",
+        Html:    htmlBody,
+    },
+    Recipients: &kibamail.BroadcastRecipients{
+        Topic: "topic_buyers",
+        // OR exactly one of:
+        // Segment:  "seg_high_intent",
+        // Contacts: []string{"ct_1", "ct_2"},
+        // Emails:   []string{"a@x.com", "b@x.com"},
+    },
+    SendAt: "2026-11-28T14:00:00Z", // RFC3339 UTC; past = immediate
+})
+// res.ID
+```
+
+### Recipients precedence
+
+Specify **exactly one** of `TopicId`, `SegmentId`, `Recipients.Contacts`, `Recipients.Emails`. Multiple is rejected with `validation_failed`.
+
+`Recipients.Emails` auto-creates contacts as `SUBSCRIBED` — use carefully, respect prior consent.
+
+## Get & list
+
+```go
+bc, _ := kb.Broadcasts.GetWithContext(ctx, bcID)
+// bc.Status ∈ draft | scheduled | sending | sent | failed
+// bc.SendAt, bc.EmailContent, bc.From, bc.ReplyTo, bc.CreatedAt
+
+list, _ := kb.Broadcasts.ListWithContext(ctx, &kibamail.ListOptions{Limit: ptr(50)})
+```
+
+## Delete (cancels if unsent)
+
+```go
+kb.Broadcasts.DeleteWithContext(ctx, bcID)
+```
+
+Only works while `Status` is `draft` or `scheduled`.
+
+## Per-recipient sends
+
+```go
+limit := 100
+status := "bounced"
+page, _ := kb.Broadcasts.ListSendsWithContext(ctx, bc.ID, &kibamail.ListBroadcastSendsOptions{
+    Limit:  &limit,
+    Status: &status, // queued | sent | delivered | bounced | complained | failed | unsubscribed
+})
+
+for _, s := range page.Data {
+    fmt.Println(s.Email, s.Status, s.LastResponseCode, s.LastResponseMessage, s.BounceClassification)
+}
+```
+
+Cursor pagination: use last `s.ID` as `After` on next call, check `page.HasMore`.
+
+## Aggregate stats
+
+```go
+stats, _ := kb.Broadcasts.StatsWithContext(ctx, bc.ID)
+fmt.Printf("delivered=%.0f/%.0f  open=%.1f%%  click=%.1f%%  bounce=%.1f%%  complaint=%.3f%%\n",
+    stats.Recipients.Delivered, stats.Recipients.Total,
+    stats.Engagement.OpenRate*100,
+    stats.Engagement.ClickRate*100,
+    stats.Deliverability.BounceRate*100,
+    stats.Deliverability.ComplaintRate*100)
+```
+
+`stats.DetailsPruned` indicates per-recipient rows have aged out of retention; aggregate numbers remain accurate.
+
+## Operational guidance
+
+- **Stats is O(1) server-side; ListSends is O(N).** For dashboards and SLA checks, prefer `Stats`.
+- **Warm up new sending domains.** Start with small batches (hundreds), grow over days. A first-send blast to 100k from a cold domain will get throttled by Gmail.
+- **Split A/B tests as two broadcasts over two segments.** Don't try to overload one broadcast.
+- **Never strip `List-Unsubscribe`.** Auto-inserted by the platform; required for Gmail/Outlook bulk-sender compliance.
+- **Schedule in UTC.** `SendAt` is RFC3339 with timezone offset; the server converts to UTC internally.

--- a/skills/kibamail-go-sdk/references/contacts.md
+++ b/skills/kibamail-go-sdk/references/contacts.md
@@ -1,0 +1,162 @@
+# Contacts — Go SDK Reference
+
+Service: `kb.Contacts`. Source: `sdks/go/contacts.go`. Each contact is keyed by `email` within a workspace.
+
+## Create
+
+```go
+res, err := kb.Contacts.CreateWithContext(ctx, &kibamail.CreateContactRequest{
+    Email:     "user@example.com",
+    FirstName: "Jane",
+    LastName:  "Doe",
+    Phone:     "+15551234567",
+    Country:   "US",
+    City:      "San Francisco",
+    Timezone:  "America/Los_Angeles",
+    Properties: map[string]interface{}{
+        "plan":           "enterprise",
+        "signed_up_at":   "2026-04-21T00:00:00Z",
+        "lifetime_value": 1248.50,
+    },
+    Topics: []string{"topic_newsletter", "topic_product_updates"},
+})
+// res.ID
+```
+
+**Property keys** must already exist as a ContactProperty definition in the workspace — unknown keys are rejected as `validation_failed`. See `references/other-resources.md`.
+
+**Topics** accepts topic IDs from `kb.Topics.List`.
+
+## Get
+
+```go
+c, err := kb.Contacts.GetWithContext(ctx, contactID)
+// c.Email, c.Status, c.FirstName, c.LastName, c.Properties, c.Topics,
+// c.CreatedAt, c.UpdatedAt
+```
+
+Status values: `SUBSCRIBED`, `UNSUBSCRIBED`, `UNCONFIRMED` (double-opt-in pending), `COMPLAINED`, `BOUNCED`.
+
+## Update (merge semantics)
+
+```go
+kb.Contacts.UpdateWithContext(ctx, contactID, &kibamail.UpdateContactRequest{
+    FirstName: "Janet",
+    Properties: map[string]interface{}{
+        "plan": "scale", // merges with existing properties
+    },
+})
+```
+
+Only keys you send are touched. To unset a property, pass `nil`:
+
+```go
+Properties: map[string]interface{}{"plan": nil}
+```
+
+## Delete
+
+```go
+if err := kb.Contacts.DeleteWithContext(ctx, contactID); err != nil { /* ... */ }
+```
+
+## List (cursor pagination)
+
+```go
+limit := 100
+page, err := kb.Contacts.ListWithContext(ctx, &kibamail.ListOptions{Limit: &limit})
+
+for page.HasMore {
+    last := page.Data[len(page.Data)-1].ID
+    page, err = kb.Contacts.ListWithContext(ctx, &kibamail.ListOptions{
+        Limit: &limit,
+        After: &last,
+    })
+    // ...
+}
+```
+
+## Search (filter DSL)
+
+```go
+res, err := kb.Contacts.SearchWithContext(ctx, &kibamail.SearchContactRequest{
+    Filters: map[string]interface{}{
+        "$and": []map[string]interface{}{
+            {"field": "status",             "operator": "equals",   "value": "SUBSCRIBED"},
+            {"field": "properties.plan",    "operator": "equals",   "value": "enterprise"},
+            {"$or": []map[string]interface{}{
+                {"field": "country", "operator": "equals", "value": "US"},
+                {"field": "country", "operator": "equals", "value": "CA"},
+            }},
+        },
+    },
+})
+```
+
+**Operators:** `equals`, `not_equals`, `greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `contains`, `not_contains`, `starts_with`, `ends_with`, `in`, `not_in`, `exists`.
+
+**Addressable fields:** `email`, `status`, `country`, `city`, `timezone`, `createdAt`, `updatedAt`, and any custom `properties.<key>`.
+
+**Topic shortcut:**
+
+```go
+Filters: map[string]interface{}{"subscribedToTopic": "topic_id"}
+```
+
+## Upsert pattern (no dedicated endpoint)
+
+```go
+func upsertContact(ctx context.Context, kb *kibamail.Client, req *kibamail.CreateContactRequest) (string, error) {
+    res, err := kb.Contacts.CreateWithContext(ctx, req)
+    if err == nil {
+        return res.ID, nil
+    }
+
+    var apiErr *kibamail.APIError
+    if errors.As(err, &apiErr) && apiErr.StatusCode == 409 {
+        // already exists — look up by email, then update
+        found, serr := kb.Contacts.SearchWithContext(ctx, &kibamail.SearchContactRequest{
+            Filters: map[string]interface{}{
+                "field": "email", "operator": "equals", "value": req.Email,
+            },
+        })
+        if serr != nil || len(found.Data) == 0 {
+            return "", serr
+        }
+        id := found.Data[0].ID
+        _, uerr := kb.Contacts.UpdateWithContext(ctx, id, &kibamail.UpdateContactRequest{
+            FirstName:  req.FirstName,
+            LastName:   req.LastName,
+            Phone:      req.Phone,
+            Properties: req.Properties,
+            Topics:     req.Topics,
+        })
+        return id, uerr
+    }
+    return "", err
+}
+```
+
+## Topics subscription workflow
+
+Attach contacts to topics at create time via the `Topics` field, or afterwards with `Update`:
+
+```go
+kb.Contacts.UpdateWithContext(ctx, contactID, &kibamail.UpdateContactRequest{
+    Topics: []string{"topic_newsletter"}, // replaces existing topic set
+})
+```
+
+The `Topics` field is a **full replacement**, not an append. To add without replacing, fetch current topics first:
+
+```go
+c, _ := kb.Contacts.GetWithContext(ctx, contactID)
+topics := append(c.Topics, "topic_new")
+kb.Contacts.UpdateWithContext(ctx, contactID, &kibamail.UpdateContactRequest{Topics: topics})
+```
+
+## Status lifecycle rules
+
+- Broadcasts and automations only target `SUBSCRIBED` contacts.
+- `COMPLAINED` and `BOUNCED` contacts cannot be re-subscribed via the API — this is a deliverability safeguard. Require a new explicit opt-in.
+- Double-opt-in forms create contacts as `UNCONFIRMED`; they move to `SUBSCRIBED` only after clicking the confirmation link.

--- a/skills/kibamail-go-sdk/references/emails.md
+++ b/skills/kibamail-go-sdk/references/emails.md
@@ -1,0 +1,177 @@
+# Emails (Transactional) — Go SDK Reference
+
+Service: `kb.Emails`. Source: `sdks/go/emails.go`.
+
+**HTML content:** generate HTML from a templating library (MJML, `html/template`) rather than hand-concatenating strings. Always include a plain-text alternative (`Text`) — it improves deliverability.
+
+**Template compliance variables:** when sending with `Template`, the template body must include `{{business_address}}`, `{{unsubscribe_url}}`, `{{terms_url}}`, `{{privacy_url}}`. Sending raw `Html` bypasses this requirement.
+
+## Send a single email
+
+```go
+res, err := kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From:    "Acme <noreply@acme.com>",
+    To:      "customer@example.com",   // string OR []string
+    Subject: "Order confirmation #1234",
+    Html:    htmlBody,
+    Text:    plainBody,
+})
+if err != nil { return err }
+log.Println("queued email id:", res.ID)
+```
+
+`To` accepts either a single `string` or `[]string` for multi-recipient (up to 50). Use discrete calls per recipient when you need per-recipient metadata.
+
+## Reply-To
+
+```go
+kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From:    "noreply@acme.com",
+    To:      "customer@example.com",
+    Subject: "We got your ticket",
+    Html:    html,
+    ReplyTo: &kibamail.SendEmailReplyTo{
+        Email: "support@acme.com",
+        Name:  "Acme Support",
+    },
+})
+```
+
+## Template-based send
+
+```go
+kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From: "billing@acme.com",
+    To:   "customer@example.com",
+    Template: &kibamail.SendEmailTemplate{
+        ID: "me_welcome_v3",
+        Variables: map[string]interface{}{
+            "firstName": "Jane",
+            "orderId":   "ord_1234",
+            "amount":    "$49.00",
+        },
+    },
+})
+```
+
+Subject and body come from the marketing email template; `Variables` are merged with Handlebars `{{ var }}` placeholders.
+
+## Attachments
+
+`Content` must be **base64-encoded**.
+
+```go
+import "encoding/base64"
+
+pdfBytes, _ := os.ReadFile("invoice.pdf")
+
+kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From:    "billing@acme.com",
+    To:      "customer@example.com",
+    Subject: "Your invoice",
+    Html:    htmlBody,
+    Attachments: []kibamail.SendEmailAttachment{{
+        Filename:    "invoice.pdf",
+        Content:     base64.StdEncoding.EncodeToString(pdfBytes),
+        ContentType: "application/pdf",
+    }},
+})
+```
+
+Per-email attachment size limit: 10 MB total across all attachments.
+
+## Metadata (custom key/value pairs)
+
+```go
+kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From:    "noreply@acme.com",
+    To:      "customer@example.com",
+    Subject: "Receipt",
+    Html:    html,
+    Metadata: map[string]string{
+        "orderId":  "ord_1234",
+        "tenant":   "acme-corp",
+        "campaign": "receipts",
+    },
+})
+```
+
+Metadata appears on webhook events and on `Emails.Get` responses — use it to correlate sends with your own entities. Keys are free-form; values are strings only.
+
+## List sent emails
+
+```go
+status := "DELIVERED"
+to := "customer@example.com"
+limit := 50
+
+page, err := kb.Emails.ListWithContext(ctx, &kibamail.ListEmailsOptions{
+    Limit:  &limit,
+    Status: &status,
+    To:     &to,
+    // FromDate, ToDate: RFC3339 strings
+})
+```
+
+`Status` is one of: `QUEUED`, `SENT`, `DELIVERED`, `BOUNCED`, `COMPLAINED`, `FAILED`.
+
+## Get a specific email
+
+```go
+e, err := kb.Emails.GetWithContext(ctx, emailID)
+// e.Status, e.LastResponseCode, e.LastResponseMessage, e.BounceClassification,
+// e.OpenCount, e.ClickCount, e.DeliveredAt, e.FirstOpenedAt, e.FirstClickedAt,
+// e.Metadata, e.Tags
+```
+
+## Event timeline
+
+```go
+events, err := kb.Emails.EventsWithContext(ctx, emailID)
+// Ordered timeline: Queued → Sent → Delivered → Opened → Clicked → ...
+```
+
+Each event carries `Type`, `Timestamp`, and `Response` (`Code` + `Content` SMTP details) where applicable.
+
+## Rendered content
+
+```go
+content, err := kb.Emails.ContentWithContext(ctx, emailID)
+// content.Html and content.Text as actually rendered and injected
+```
+
+Useful for debugging rendering issues — shows the final HTML post-variable-merge.
+
+## Production patterns
+
+### Bounded concurrency for burst sends
+
+```go
+sem := make(chan struct{}, 16) // cap at 16 concurrent sends
+var wg sync.WaitGroup
+for _, r := range recipients {
+    r := r
+    sem <- struct{}{}
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        defer func() { <-sem }()
+        if _, err := kb.Emails.SendWithContext(ctx, buildReq(r)); err != nil {
+            log.Printf("send %s: %v", r.Email, err)
+        }
+    }()
+}
+wg.Wait()
+```
+
+Pick the cap based on your rate limit. Never fire unbounded goroutines at `Emails.Send`.
+
+### Idempotency for retries
+
+The `Send` endpoint is not auto-idempotent. If your worker retries after a network error, the same email may send twice. Deduplicate upstream by writing your own lookup key to `Metadata`:
+
+```go
+Metadata: map[string]string{"idempotencyKey": "order_1234_receipt"}
+```
+
+Before retrying, search for that key in `Emails.List` (filter by metadata not yet SDK-exposed — alternatively, short-circuit in your own DB).

--- a/skills/kibamail-go-sdk/references/forms.md
+++ b/skills/kibamail-go-sdk/references/forms.md
@@ -1,0 +1,137 @@
+# Forms — Go SDK Reference
+
+Service: `kb.Forms`. Source: `sdks/go/forms.go`. Forms collect subscriber data into your workspace. Each form has a `fieldMapping` (public name → contact field/property/topic) and optional SEO + double-opt-in + slug config.
+
+## Create
+
+```go
+doiEmailID := "me_welcome_doi"
+
+form, err := kb.Forms.CreateWithContext(ctx, &kibamail.CreateFormRequest{
+    Name:        "Newsletter signup",
+    Description: "Top-of-funnel lead magnet",
+    Type:        "inline", // inline | popup | modal | standalone
+    FieldMapping: map[string]interface{}{
+        "email":      map[string]interface{}{"type": "system",   "target": "email", "required": true},
+        "first_name": map[string]interface{}{"type": "system",   "target": "firstName"},
+        "plan":       map[string]interface{}{"type": "property", "target": "plan"},
+        "topics":     map[string]interface{}{"type": "topics",   "target": []string{"topic_newsletter"}},
+    },
+    DoubleOptInEmailId: &doiEmailID, // omit for single opt-in
+})
+// form.ID
+```
+
+## Get
+
+```go
+f, err := kb.Forms.GetWithContext(ctx, formID)
+// f.Status, f.HTML, f.DeployId, f.DeployedFiles (CDN URLs),
+// f.FieldMapping, f.Settings, f.Slug,
+// f.SeoTitle, f.SeoDescription, f.SeoImageUrl, f.SeoFaviconUrl,
+// f.DoubleOptInEmailId, f.CreatedAt, f.UpdatedAt
+```
+
+## Update
+
+```go
+slug := "weekly"
+seoTitle := "Weekly product digest"
+
+kb.Forms.UpdateWithContext(ctx, formID, &kibamail.UpdateFormRequest{
+    Slug:     &slug,
+    SeoTitle: &seoTitle,
+    Settings: map[string]interface{}{
+        "submitButtonText": "Subscribe",
+        "successMessage":   "Check your inbox!",
+    },
+})
+```
+
+## Delete
+
+```go
+kb.Forms.DeleteWithContext(ctx, formID)
+```
+
+## List
+
+```go
+list, err := kb.Forms.ListWithContext(ctx, &kibamail.ListOptions{Limit: ptr(50)})
+```
+
+## Deploy static assets
+
+Upload CSS/JS/images to Kibamail's CDN (multipart). Returns CDN URLs to reference in your form HTML:
+
+```go
+deploy, err := kb.Forms.DeployWithContext(ctx, formID, []kibamail.FileUpload{
+    {Name: "style.css", Content: cssBytes, ContentType: "text/css"},
+    {Name: "logo.png",  Content: pngBytes, ContentType: "image/png"},
+})
+// deploy.DeployId
+// deploy.Files[].URL  → e.g. https://cdn.kibamail.com/forms/<id>/<deploy>/logo.png
+```
+
+## Publish (snapshot current draft as live)
+
+Forms are drafts until published. A publish snapshots the current `fieldMapping`, `html`, and deployed assets as the live version.
+
+```go
+kb.Forms.PublishWithContext(ctx, formID)
+```
+
+## Versioning
+
+Create a new version rather than mutating a live form in place. In-flight submissions keep resolving against the version they started on:
+
+```go
+kb.Forms.CreateVersionWithContext(ctx, formID, &kibamail.CreateFormVersionRequest{
+    Name:         "v2 — added plan dropdown",
+    FieldMapping: updatedMapping,
+})
+
+versions, _ := kb.Forms.ListVersionsWithContext(ctx, formID)
+// versions.Data[i].Version is monotonically increasing int
+```
+
+## Server-side submit
+
+For submissions made from your own backend (e.g. proxying a custom-designed form):
+
+```go
+res, err := kb.Forms.SubmitWithContext(ctx, formID, map[string]interface{}{
+    "email":      "new@example.com",
+    "first_name": "Sam",
+    "plan":       "starter",
+})
+// res.ID — submission id
+```
+
+Submit honors the form's `fieldMapping`, rejects unknown keys, and triggers the double-opt-in email if configured. The resulting contact is `SUBSCRIBED` for single-opt-in forms and `UNCONFIRMED` for DOI forms until the confirmation link is clicked.
+
+## Double opt-in
+
+1. Create a marketing email template containing the confirmation link (see `marketing-emails.md`).
+2. Pass its ID as `DoubleOptInEmailId` on form create/update.
+3. Submitted contacts become `UNCONFIRMED`; they're auto-promoted to `SUBSCRIBED` after the click.
+
+To switch back to single-opt-in, set `DoubleOptInEmailId: ptr("")`.
+
+## Field mapping reference
+
+```go
+map[string]interface{}{
+    "<public_name>": map[string]interface{}{
+        "type":     "system" | "property" | "topics",
+        "target":   "<contact field | property key | []string of topic IDs>",
+        "required": true,  // optional
+    },
+}
+```
+
+System targets: `email`, `firstName`, `lastName`, `phone`, `country`, `city`, `timezone`.
+
+Property targets: any key defined in `ContactProperties`.
+
+Topics target: an array of topic IDs — contact is subscribed to all of them on submit.

--- a/skills/kibamail-go-sdk/references/integration-patterns.md
+++ b/skills/kibamail-go-sdk/references/integration-patterns.md
@@ -1,0 +1,313 @@
+# Integration Patterns — Go SDK
+
+Wiring the Kibamail client into common Go backend shapes. All examples use `context.Context` correctly and share a single `*kibamail.Client` per process.
+
+## Pattern 1 — `net/http`
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "net/http"
+    "os"
+    "time"
+
+    kibamail "github.com/kibamail/kibamail/sdks/go"
+)
+
+type Server struct {
+    kb *kibamail.Client
+}
+
+func main() {
+    httpClient := &http.Client{Timeout: 15 * time.Second}
+    kb := kibamail.NewCustomClient(httpClient, os.Getenv("KIBAMAIL_API_KEY"))
+
+    s := &Server{kb: kb}
+
+    mux := http.NewServeMux()
+    mux.HandleFunc("POST /signup", s.signup)
+
+    srv := &http.Server{
+        Addr:              ":8080",
+        Handler:           mux,
+        ReadHeaderTimeout: 5 * time.Second,
+    }
+    log.Fatal(srv.ListenAndServe())
+}
+
+type signupReq struct {
+    Email     string `json:"email"`
+    FirstName string `json:"firstName"`
+}
+
+func (s *Server) signup(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+    defer cancel()
+
+    var body signupReq
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    res, err := s.kb.Contacts.CreateWithContext(ctx, &kibamail.CreateContactRequest{
+        Email:     body.Email,
+        FirstName: body.FirstName,
+        Topics:    []string{"topic_newsletter"},
+    })
+    if err != nil {
+        writeAPIError(w, err)
+        return
+    }
+
+    // Fire welcome email
+    _, _ = s.kb.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+        From:    "Acme <hello@acme.com>",
+        To:      body.Email,
+        Subject: "Welcome to Acme",
+        Template: &kibamail.SendEmailTemplate{
+            ID: "me_welcome_v3",
+            Variables: map[string]interface{}{"firstName": body.FirstName},
+        },
+    })
+
+    w.WriteHeader(http.StatusCreated)
+    _ = json.NewEncoder(w).Encode(map[string]string{"contactId": res.ID})
+}
+```
+
+## Pattern 2 — Gin
+
+```go
+package main
+
+import (
+    "net/http"
+    "os"
+    "time"
+
+    "github.com/gin-gonic/gin"
+    kibamail "github.com/kibamail/kibamail/sdks/go"
+)
+
+func main() {
+    kb := kibamail.NewCustomClient(
+        &http.Client{Timeout: 15 * time.Second},
+        os.Getenv("KIBAMAIL_API_KEY"),
+    )
+
+    r := gin.Default()
+    r.Use(func(c *gin.Context) { c.Set("kb", kb); c.Next() })
+
+    r.POST("/contacts", createContact)
+    _ = r.Run(":8080")
+}
+
+func createContact(c *gin.Context) {
+    kb := c.MustGet("kb").(*kibamail.Client)
+
+    var body kibamail.CreateContactRequest
+    if err := c.ShouldBindJSON(&body); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
+
+    res, err := kb.Contacts.CreateWithContext(c.Request.Context(), &body)
+    if err != nil {
+        writeAPIErrorGin(c, err)
+        return
+    }
+    c.JSON(http.StatusCreated, res)
+}
+```
+
+## Pattern 3 — Echo
+
+```go
+e := echo.New()
+e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+    return func(c echo.Context) error { c.Set("kb", kb); return next(c) }
+})
+e.POST("/emails/send", func(c echo.Context) error {
+    kb := c.Get("kb").(*kibamail.Client)
+    var req kibamail.SendEmailRequest
+    if err := c.Bind(&req); err != nil { return err }
+    res, err := kb.Emails.SendWithContext(c.Request().Context(), &req)
+    if err != nil { return err }
+    return c.JSON(http.StatusOK, res)
+})
+```
+
+## Pattern 4 — chi
+
+```go
+r := chi.NewRouter()
+r.Use(middleware.Timeout(15 * time.Second))
+r.Post("/contacts", func(w http.ResponseWriter, r *http.Request) {
+    var body kibamail.CreateContactRequest
+    _ = json.NewDecoder(r.Body).Decode(&body)
+    res, err := kb.Contacts.CreateWithContext(r.Context(), &body)
+    // ...
+})
+```
+
+## Pattern 5 — Background worker (queue consumer)
+
+```go
+type Job struct {
+    ContactID string
+    OrderID   string
+}
+
+func processReceiptJob(ctx context.Context, kb *kibamail.Client, j Job) error {
+    // Bound per-call
+    jobCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+    defer cancel()
+
+    _, err := kb.Emails.SendWithContext(jobCtx, &kibamail.SendEmailRequest{
+        From: "billing@acme.com",
+        To:   resolveEmail(j.ContactID),
+        Template: &kibamail.SendEmailTemplate{
+            ID: "me_receipt_v2",
+            Variables: map[string]interface{}{"orderId": j.OrderID},
+        },
+        Metadata: map[string]string{
+            "idempotencyKey": "receipt_" + j.OrderID,
+            "orderId":        j.OrderID,
+        },
+    })
+    return err
+}
+```
+
+## Canonical error handler (shared helper)
+
+```go
+func writeAPIError(w http.ResponseWriter, err error) {
+    var apiErr *kibamail.APIError
+    if errors.As(err, &apiErr) {
+        log.Printf("kibamail: code=%s msg=%s reqId=%s", apiErr.Code, apiErr.Message, apiErr.RequestID)
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(apiErr.StatusCode)
+        _ = json.NewEncoder(w).Encode(map[string]any{
+            "code":             apiErr.Code,
+            "message":          apiErr.Message,
+            "hint":             apiErr.Hint,
+            "requestId":        apiErr.RequestID,
+            "validationErrors": apiErr.ValidationErrors,
+        })
+        return
+    }
+
+    var rl *kibamail.RateLimitError
+    if errors.As(err, &rl) {
+        w.Header().Set("Retry-After", rl.RetryAfter)
+        http.Error(w, "rate limited — retry in "+rl.RetryAfter+"s", http.StatusTooManyRequests)
+        return
+    }
+
+    // transport / context error
+    http.Error(w, "internal error", http.StatusInternalServerError)
+}
+```
+
+## Retry wrapper (exponential backoff + jitter)
+
+```go
+import (
+    "math/rand"
+    "time"
+)
+
+func retryable(err error) bool {
+    var rl *kibamail.RateLimitError
+    if errors.As(err, &rl) { return true }
+    var apiErr *kibamail.APIError
+    if errors.As(err, &apiErr) {
+        return apiErr.StatusCode >= 500 || apiErr.StatusCode == 408
+    }
+    // transport errors are typically retryable
+    return err != nil && !errors.Is(err, context.Canceled)
+}
+
+func withRetry[T any](ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
+    var zero T
+    attempts := 3
+    base := 250 * time.Millisecond
+
+    for i := 0; i < attempts; i++ {
+        v, err := fn(ctx)
+        if err == nil { return v, nil }
+        if !retryable(err) || i == attempts-1 { return zero, err }
+
+        var rl *kibamail.RateLimitError
+        if errors.As(err, &rl) && rl.RetryAfter != "" {
+            if d, perr := time.ParseDuration(rl.RetryAfter + "s"); perr == nil {
+                select {
+                case <-time.After(d):
+                case <-ctx.Done():
+                    return zero, ctx.Err()
+                }
+                continue
+            }
+        }
+
+        backoff := base * (1 << i)
+        jitter := time.Duration(rand.Int63n(int64(backoff) / 2))
+        select {
+        case <-time.After(backoff + jitter):
+        case <-ctx.Done():
+            return zero, ctx.Err()
+        }
+    }
+    return zero, errors.New("unreachable")
+}
+
+// Usage:
+res, err := withRetry(ctx, func(ctx context.Context) (*kibamail.SendEmailResponse, error) {
+    return kb.Emails.SendWithContext(ctx, req)
+})
+```
+
+## Graceful shutdown
+
+The SDK has no shutdown hook — HTTP connection pooling is handled by `*http.Client`. Best practice:
+
+```go
+// In main(), after server.Shutdown(ctx):
+if t, ok := httpClient.Transport.(*http.Transport); ok {
+    t.CloseIdleConnections()
+}
+```
+
+Run this after your HTTP server has stopped accepting new requests to drain idle Kibamail connections cleanly.
+
+## Testing — mock the HTTP transport
+
+Don't mock the SDK; stub the transport:
+
+```go
+type stubTransport struct {
+    fn func(*http.Request) (*http.Response, error)
+}
+func (s *stubTransport) RoundTrip(r *http.Request) (*http.Response, error) { return s.fn(r) }
+
+httpClient := &http.Client{Transport: &stubTransport{
+    fn: func(r *http.Request) (*http.Response, error) {
+        assert.Equal(t, "/v1/contacts", r.URL.Path)
+        body := `{"id":"ct_mock"}`
+        return &http.Response{
+            StatusCode: 201,
+            Header:     http.Header{"Content-Type": []string{"application/json"}},
+            Body:       io.NopCloser(strings.NewReader(body)),
+        }, nil
+    },
+}}
+kb := kibamail.NewCustomClient(httpClient, "kb_test_key")
+```
+
+This gives you full control over what the SDK "sees" without network calls and without hand-rolling interface mocks for every service.

--- a/skills/kibamail-go-sdk/references/marketing-emails.md
+++ b/skills/kibamail-go-sdk/references/marketing-emails.md
@@ -1,0 +1,100 @@
+# Marketing Emails — Go SDK Reference
+
+Service: `kb.MarketingEmails`. Source: `sdks/go/marketing_emails.go`. Reusable templates consumed by:
+
+- `kb.Emails.Send` with `Template` field — transactional send with variable injection.
+- `kb.Broadcasts.Create` — one-off marketing campaigns.
+- `kb.Automations` send nodes — automated flows.
+- `kb.Forms` `doubleOptInEmailId` — DOI confirmation.
+
+## Create
+
+```go
+trackOpens := true
+trackClicks := true
+
+res, err := kb.MarketingEmails.CreateWithContext(ctx, &kibamail.CreateMarketingEmailRequest{
+    Name:              "Welcome email v3",
+    Subject:           "Welcome to {{ company }}, {{ firstName }}",
+    PreviewText:       "Quick 3-step setup inside.",
+    Html:              htmlWithHandlebars, // see Compliance Variables below
+    SenderIdentityId:  "si_team_hello",
+    ReplyToIdentityId: "si_support_inbox", // optional
+    TrackOpens:        &trackOpens,
+    TrackClicks:       &trackClicks,
+    Type:              "TRANSACTIONAL_TEMPLATE", // or MARKETING
+})
+// res.ID
+```
+
+## Compliance variables (marketing templates)
+
+Templates used for marketing sends must include these Handlebars tokens in the HTML body — the API validates on save:
+
+- `{{business_address}}`
+- `{{unsubscribe_url}}`
+- `{{terms_url}}`
+- `{{privacy_url}}`
+
+`TRANSACTIONAL_TEMPLATE` type is exempt from this requirement.
+
+## Get
+
+```go
+tmpl, err := kb.MarketingEmails.GetWithContext(ctx, templateID)
+// tmpl.Variables = []string{"company","firstName",...} parsed from Html
+// tmpl.TrackOpens, tmpl.TrackClicks, tmpl.CreatedAt, tmpl.UpdatedAt
+```
+
+## List
+
+```go
+list, err := kb.MarketingEmails.ListWithContext(ctx, &kibamail.ListOptions{Limit: ptr(50)})
+for _, t := range list.Data {
+    fmt.Println(t.ID, t.Name, t.Subject)
+}
+```
+
+## Update
+
+```go
+kb.MarketingEmails.UpdateWithContext(ctx, templateID, &kibamail.UpdateMarketingEmailRequest{
+    Subject: "Welcome to Kibamail, {{ firstName }}",
+    Html:    updatedHTML,
+})
+```
+
+## Delete
+
+```go
+kb.MarketingEmails.DeleteWithContext(ctx, templateID)
+```
+
+Fails if the template is currently referenced by a form (double-opt-in), an automation node, or a scheduled broadcast. Check `Stats.UsedByForms` first.
+
+## Preview (rendered HTML)
+
+```go
+p, err := kb.MarketingEmails.PreviewWithContext(ctx, templateID)
+// p.Html        — fully rendered with placeholder sample data
+// p.HasContent  — false for empty/whitespace templates
+```
+
+Useful in CI: snapshot-test rendered output before allowing a PR to merge template changes.
+
+## Stats
+
+```go
+s, err := kb.MarketingEmails.StatsWithContext(ctx, templateID)
+fmt.Printf("sent=%d delivered=%d opens=%d clicks=%d OR=%.1f%% CTR=%.1f%%\n",
+    s.TotalSent, s.TotalDelivered, s.TotalOpened, s.TotalClicked,
+    s.OpenRate*100, s.ClickRate*100)
+
+for _, f := range s.UsedByForms {
+    fmt.Printf("referenced by form %s (%s)\n", f.ID, f.Name)
+}
+```
+
+## Handlebars variable merging
+
+At send time, `SendEmailTemplate.Variables` or automation context variables are merged into the HTML. Variables referenced in the template but missing at send time render as empty strings — there is no strict mode. Guard critical values in your own code before calling Send.

--- a/skills/kibamail-go-sdk/references/other-resources.md
+++ b/skills/kibamail-go-sdk/references/other-resources.md
@@ -1,0 +1,159 @@
+# Other Resources — Go SDK Reference
+
+Quick reference for resources without dedicated docs.
+
+## Domains — `kb.Domains`
+
+Sending-domain setup: add a domain, publish DNS records, verify, enable tracking.
+
+```go
+// Create (dmarc optional)
+d, _ := kb.Domains.CreateWithContext(ctx, &kibamail.CreateDomainRequest{
+    Name:         "mail.acme.com",
+    DmarcEnabled: true,
+})
+// d.DnsRecords.Dkim / ReturnPath / Tracking — publish these to your DNS provider.
+//   Each has Type (TXT/CNAME), Hostname, Value.
+
+// List & get
+list, _ := kb.Domains.ListWithContext(ctx, nil)
+d, _ = kb.Domains.GetWithContext(ctx, d.ID)
+// d.DkimVerified, d.ReturnPathVerified, d.TrackingVerified,
+// d.OpenTrackingEnabled, d.ClickTrackingEnabled, d.SslStatus, d.SslError
+
+// Update tracking flags
+kb.Domains.UpdateWithContext(ctx, d.ID, &kibamail.UpdateDomainRequest{
+    OpenTrackingEnabled:  ptr(true),
+    ClickTrackingEnabled: ptr(true),
+})
+
+// Verify (actively re-checks DNS)
+v, _ := kb.Domains.VerifyWithContext(ctx, d.ID)
+if v.Verification.AllVerified { /* ready to send */ }
+// Otherwise inspect v.Verification.Dkim/ReturnPath/Tracking/Dmarc:
+//   .Configured, .Expected, .Found (actual records seen)
+
+// Delete
+kb.Domains.DeleteWithContext(ctx, d.ID)
+```
+
+**Typical flow:** Create → publish DNS records from `DnsRecords` → poll `Verify` until `AllVerified: true` → start sending.
+
+## Topics — `kb.Topics`
+
+Interest lists a contact can subscribe/unsubscribe from. Powers broadcast recipient targeting and one-click unsubscribe.
+
+```go
+t, _ := kb.Topics.CreateWithContext(ctx, &kibamail.CreateTopicRequest{
+    Name:        "Product updates",
+    Description: "Monthly roundup of new features",
+})
+list, _  := kb.Topics.ListWithContext(ctx, nil)
+t, _      = kb.Topics.GetWithContext(ctx, t.ID)
+kb.Topics.UpdateWithContext(ctx, t.ID, &kibamail.UpdateTopicRequest{Name: "Monthly updates"})
+kb.Topics.DeleteWithContext(ctx, t.ID)
+
+// List contacts subscribed to a topic
+contacts, _ := kb.Topics.ListContactsWithContext(ctx, t.ID, nil)
+```
+
+## Segments — `kb.Segments`
+
+Dynamic contact groups defined by a filter expression.
+
+```go
+seg, _ := kb.Segments.CreateWithContext(ctx, &kibamail.CreateSegmentRequest{
+    Name: "Engaged US enterprise",
+    Filters: map[string]interface{}{
+        "$and": []map[string]interface{}{
+            {"field": "country",              "operator": "equals",       "value": "US"},
+            {"field": "properties.plan",      "operator": "equals",       "value": "enterprise"},
+            {"field": "lastOpenedAt",         "operator": "greater_than", "value": "2026-01-01"},
+        },
+    },
+})
+
+kb.Segments.ListWithContext(ctx, nil)
+kb.Segments.GetWithContext(ctx, seg.ID)
+kb.Segments.UpdateWithContext(ctx, seg.ID, &kibamail.UpdateSegmentRequest{Name: "Updated"})
+kb.Segments.DeleteWithContext(ctx, seg.ID)
+```
+
+Segments are evaluated at send time for broadcasts and on contact changes for automations (`segment.entered` / `segment.exited` triggers).
+
+## Contact Properties — `kb.ContactProperties`
+
+Workspace-wide custom field definitions. Contacts can only set properties whose keys are defined here.
+
+```go
+kb.ContactProperties.CreateWithContext(ctx, &kibamail.CreateContactPropertyRequest{
+    Name: "plan",
+    Type: "TEXT", // TEXT | NUMBER | BOOLEAN | DATE | JSON
+})
+
+kb.ContactProperties.ListWithContext(ctx, nil)
+kb.ContactProperties.GetWithContext(ctx, propID)
+kb.ContactProperties.UpdateWithContext(ctx, propID, &kibamail.UpdateContactPropertyRequest{Name: "subscription_plan"})
+kb.ContactProperties.DeleteWithContext(ctx, propID) // removes key from all contacts
+```
+
+Define all properties up front. Adding a property after contacts exist doesn't retro-fill them — the value is `nil` until set.
+
+## Events — `kb.Events`
+
+Custom analytics events attached to a contact. Used as automation triggers and for behavior-based segmentation.
+
+```go
+kb.Events.CreateWithContext(ctx, &kibamail.CreateEventRequest{
+    ContactId: "ct_abc",
+    Name:      "purchase.completed",
+    Properties: map[string]interface{}{
+        "orderId": "ord_1234",
+        "total":   149.00,
+        "currency": "USD",
+    },
+})
+```
+
+Events are append-only (no list/update/delete via SDK). Query them indirectly via segments (`event.occurred` filter) and automations (`event.occurred` trigger).
+
+## Inbox — `kb.Inbox`
+
+Inbound mail handling: incoming emails to your sending domain become conversations.
+
+```go
+convs, _ := kb.Inbox.ListConversationsWithContext(ctx, nil)
+
+c, _ := kb.Inbox.GetConversationWithContext(ctx, convID)
+// c.Status, c.Subject, c.From, c.Messages[]
+
+kb.Inbox.UpdateConversationWithContext(ctx, convID, &kibamail.UpdateConversationRequest{
+    Status: ptr("resolved"), // open | resolved | archived
+})
+
+kb.Inbox.ReplyWithContext(ctx, convID, &kibamail.InboxReplyRequest{
+    Html: "<p>Thanks for reaching out.</p>",
+    Text: "Thanks for reaching out.",
+})
+
+stats, _ := kb.Inbox.StatsWithContext(ctx, nil)
+```
+
+Use the Inbox API to build a support/helpdesk integration on top of transactional reply handling.
+
+## API Keys — `kb.ApiKeys`
+
+Admin-scope operation: provisioning keys for other services. Requires a key with `admin` scope — not for end-user-facing code paths.
+
+```go
+key, _ := kb.ApiKeys.CreateWithContext(ctx, &kibamail.CreateApiKeyRequest{
+    Name:   "worker-prod",
+    Scopes: []string{"write:emails", "read:emails", "read:contacts"},
+})
+// key.Token — the raw value. Shown ONCE, store immediately.
+
+kb.ApiKeys.ListWithContext(ctx, nil) // token is never returned on list
+kb.ApiKeys.DeleteWithContext(ctx, key.ID)
+```
+
+Rotate keys on a cadence; never commit them; scope each key to the minimum required permissions.

--- a/skills/kibamail-go-sdk/references/transactional-email-templates.md
+++ b/skills/kibamail-go-sdk/references/transactional-email-templates.md
@@ -1,0 +1,227 @@
+# Transactional Email Templates
+
+HTML-only reusable templates for transactional messages (receipts, OTP,
+password reset, magic links, order confirmations). Unlike marketing email
+templates, these:
+
+- carry raw HTML as the source of truth (no visual-editor JSON)
+- require only `{{business_address}}` for compliance (no unsubscribe)
+- are referenced by `POST /v1/emails/send` via their `uniqueSlug`
+
+**API path:** `/v1/transactional-email-templates`
+**Service:** `client.TransactionalEmailTemplates`
+**Scopes:** `read:templates`, `manage:templates`
+
+---
+
+## Lifecycle
+
+```
+          create (publish:true)                 create-version
+ ┌──────┐ ──────────────────► ┌───────────┐ ──────────────────► ┌─────────┐
+ │ none │                     │ PUBLISHED │                     │  DRAFT  │
+ └──────┘                     └───────────┘                     └─────────┘
+     │  create (publish:false)       ▲                                │
+     └────────────┐                   │ publish (promotes              │
+                  ▼                   │ and archives previous)         │
+              ┌───────┐               └────────────────────────────────┘
+              │ DRAFT │
+              └───────┘
+```
+
+- **DRAFT** → editable via `Update`, can be published or deleted.
+- **PUBLISHED** → immutable, resolvable by `POST /v1/emails/send`.
+- **ARCHIVED** → previous versions after a successor is published.
+
+Only one DRAFT per template family at a time. Only one PUBLISHED at a time.
+
+---
+
+## Create and publish in one call (recommended)
+
+```go
+import (
+    "context"
+    "os"
+
+    kibamail "github.com/kibamail/kibamail/sdks/go"
+)
+
+html, err := os.ReadFile("templates/receipt.html")
+if err != nil {
+    return err
+}
+
+resp, err := client.TransactionalEmailTemplates.CreateWithContext(ctx,
+    &kibamail.CreateTransactionalEmailTemplateRequest{
+        Name:        "Order Receipt",
+        UniqueSlug:  "order-receipt-v1",
+        Subject:     "Receipt for order #{{orderNumber}}",
+        PreviewText: "Thanks for your order",
+        Html:        string(html),
+        TrackClicks: kibamail.BoolPtr(true),
+        TrackOpens:  kibamail.BoolPtr(true),
+        // Publish defaults to true server-side; pass BoolPtr(false) for DRAFT.
+    },
+)
+```
+
+On success `resp.Status == "PUBLISHED"` and you can immediately send:
+
+```go
+_, err = client.Emails.SendWithContext(ctx, &kibamail.SendEmailRequest{
+    From: kibamail.EmailAddress{Email: "orders@yourdomain.com"},
+    To:   []kibamail.EmailAddress{{Email: "customer@example.com"}},
+    Template: &kibamail.EmailTemplateReference{
+        ID: "order-receipt-v1", // the uniqueSlug
+        Variables: map[string]any{
+            "orderNumber": "A-1138",
+            "firstName":   "Alex",
+        },
+    },
+})
+```
+
+---
+
+## HTML requirements
+
+### Compliance (transactional)
+
+The only required variable is `{{business_address}}`. The SDK will reject
+HTML missing it with a 400 `VALIDATION_FAILED`.
+
+**Do not** include `{{unsubscribe_url}}` in transactional mail — it
+confuses recipients and some regulators treat it as a marketing signal.
+Transactional mail is functional by definition.
+
+Marketing compliance variables (`{{unsubscribe_url}}`, `{{terms_url}}`,
+`{{privacy_url}}`) are only required for broadcasts, automation marketing
+emails, and double-opt-in forms — not here.
+
+### Handlebars-compatible variables
+
+Use `{{variableName}}` syntax. Resolution at send time happens against:
+
+1. `template.variables` from the send request (highest priority)
+2. Workspace compliance settings (`business_address`, etc.)
+
+Unsubstituted variables are preserved verbatim — failing loud is safer
+than silently sending `"Hello "` instead of `"Hello Alex"`.
+
+### Declared variables (optional)
+
+Pass typed definitions for documentation + type-check-at-send:
+
+```go
+req.Variables = []kibamail.VariableDefinition{
+    {ID: "orderNumber", Name: "orderNumber", Type: "text"},
+    {ID: "total",       Name: "total",       Type: "number"},
+}
+```
+
+If the send call passes a `text` variable where a `number` is declared,
+the send is rejected.
+
+---
+
+## Editing a published template (versioning)
+
+Published templates are immutable. To ship a new copy:
+
+```go
+// 1. Create a DRAFT version — auto-copies subject/html from source
+version, _ := client.TransactionalEmailTemplates.CreateVersionWithContext(
+    ctx, "tpl_abc",
+)
+
+// 2. Edit the new DRAFT
+_, _ = client.TransactionalEmailTemplates.UpdateWithContext(ctx, version.ID,
+    &kibamail.UpdateTransactionalEmailTemplateRequest{
+        Html:    string(newHtml),
+        Subject: "Updated subject",
+    },
+)
+
+// 3. Publish — this archives the current live version atomically
+_, _ = client.TransactionalEmailTemplates.PublishWithContext(ctx, version.ID)
+```
+
+Subsequent sends referencing the original `uniqueSlug` resolve to the new
+published version. No code change on the send side.
+
+List all versions of a template family with
+`ListVersionsWithContext(ctx, templateID)`.
+
+---
+
+## Preview before publishing
+
+```go
+preview, err := client.TransactionalEmailTemplates.PreviewWithContext(
+    ctx, templateID,
+)
+if err != nil { return err }
+_ = os.WriteFile("preview.html", []byte(preview.Html), 0o644)
+```
+
+The `Html` field has built-in `SAMPLE_VARIABLES` (e.g. `firstName → "Jane"`)
+substituted so you can open the file in a browser without a live send. Use
+in CI to snapshot-test design regressions.
+
+---
+
+## Error handling
+
+| Status | Code | Meaning | Fix |
+|---|---|---|---|
+| 400 | `VALIDATION_FAILED` | HTML missing `{{business_address}}` or malformed | Append compliance footer |
+| 400 | `INVALID_PARAMETER` | Update called on PUBLISHED template | Create a new version first |
+| 404 | `RESOURCE_NOT_FOUND` | Template id or slug not in workspace | Check `uniqueSlug` / ID |
+| 409 | `RESOURCE_ALREADY_EXISTS` | Duplicate `uniqueSlug` | Choose a unique slug or update existing |
+
+Use `errors.As(err, &apiErr)` on `*kibamail.APIError` to branch on `Code`.
+
+---
+
+## CLI
+
+The `kibamail` binary wraps every method:
+
+```bash
+kibamail transactional-email-templates create \
+  --name "Order Receipt" \
+  --slug order-receipt-v1 \
+  --subject "Receipt for order #{{orderNumber}}" \
+  --html-file templates/receipt.html \
+  --sender-identity-id si_xxx
+
+kibamail transactional-email-templates list
+kibamail transactional-email-templates show tpl_abc
+kibamail transactional-email-templates preview tpl_abc
+kibamail transactional-email-templates create-version tpl_abc
+kibamail transactional-email-templates update tpl_abc --html-file templates/receipt-v2.html
+kibamail transactional-email-templates publish tpl_abc
+```
+
+**`--html-file` vs `--html`:** always prefer `--html-file` — inline HTML
+breaks on Handlebars `{{ }}`, CSS curly braces, backticks, and multi-line
+bodies. The two flags are mutually exclusive; use one or the other.
+
+Aliases `tet` and `transactional-templates` work everywhere
+`transactional-email-templates` does.
+
+---
+
+## When to use this vs. inline HTML on Emails.Send
+
+| Situation | Use |
+|---|---|
+| One-off ad-hoc send | Inline `Html` on `SendEmailRequest` |
+| Same template fired from >1 call site | `TransactionalEmailTemplates` + `uniqueSlug` |
+| Need to version / A-B / approve before rollout | `TransactionalEmailTemplates` + `CreateVersion` → `Publish` |
+| Non-engineer needs to edit the template | Internal dashboard (visual editor) — still resolvable from `Emails.Send` by the same `uniqueSlug` |
+
+The slug namespace is shared with the dashboard. An ops-owned template
+edited in the UI and an engineering-owned template uploaded via this SDK
+are indistinguishable from the send side.


### PR DESCRIPTION
Adds a production-grade external API for LLM/programmatic management of transactional email templates, with matching Go SDK service, CLI command, and skill reference.

## Backend
- `POST/GET /api/v1/transactional-email-templates` + `[templateId]` (GET/PUT/DELETE) + `/publish`, `/preview`, `/versions`
- API-key auth, scopes: `read:templates` / `manage:templates`
- One-shot `publish: true` flag for idempotent LLM upserts
- `validateEmailCompliance` now scoped by type: TRANSACTIONAL requires only `{{business_address}}`; MARKETING retains all four vars
- `publishEmailTemplate` accepts HTML-only publishing (skips JSON→HTML render when `contentHtml` present)
- 14 integration tests, all passing; no regressions in marketing-emails tests

## Go SDK (`sdks/go`)
- New `TransactionalEmailTemplates` service with full CRUD + publish/preview/versions
- Registered on `Client` with typed error sentinels
- CLI: `kibamail transactional-email-templates {create,list,show,update,delete,publish,preview}` with `--html-file`
- `--html-file` also backported to `marketing-emails create/update`

## Skill
- `skills/kibamail-go-sdk/references/transactional-email-templates.md` with full LLM usage guide + index entry in SKILL.md